### PR TITLE
fix: deploy erc20 contract error, op code push0 not valid

### DIFF
--- a/scripts/start-artela.sh
+++ b/scripts/start-artela.sh
@@ -2,8 +2,9 @@
 
 DATA_DIR="$HOME/.artelad"
 
-sed -i 's/127.0.0.1/0.0.0.0/' $DATA_DIR/config/app.toml
-sed -i 's/127.0.0.1/0.0.0.0/' $DATA_DIR/config/config.toml
+sed -i 's/127.0.0.1/0.0.0.0/g' $DATA_DIR/config/app.toml
+sed -i 's/127.0.0.1/0.0.0.0/g' $DATA_DIR/config/config.toml
+sed -i 's/"extra_eips": \[\]/"extra_eips": \[3855\]/g' $DATA_DIR/config/genesis.json
 
 echo "starting artela node $i in background ..."
 ./artelad start --pruning=nothing \


### PR DESCRIPTION
1. Swith EVM version, apply 3855 update to resolve  push0 issue for ERC20 contract.