### PR TITLE
fix/legacy-tx: allow legacy tx by setting allow-unprotected-txs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,6 @@ WORKDIR /go/src/github.com/artela-network
 
 # Add source files
 COPY ./artela ./artela
-COPY ./artela-cosmos-sdk ./artela-cosmos-sdk
-COPY ./evm ./evm
-COPY ./artelasdk ./artelasdk
-COPY ./runtime ./runtime
 
 # Reset the working directory for the build
 WORKDIR /go/src/github.com/artela-network/artela

--- a/cmd/artelad/cmd/config.go
+++ b/cmd/artelad/cmd/config.go
@@ -3,21 +3,63 @@ package cmd
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/artela-network/artela/app"
+	artelatypes "github.com/artela-network/artela/ethereum/types"
 )
 
-func initSDKConfig() {
-	// Set prefixes
-	accountPubKeyPrefix := app.AccountAddressPrefix + "pub"
-	validatorAddressPrefix := app.AccountAddressPrefix + "valoper"
-	validatorPubKeyPrefix := app.AccountAddressPrefix + "valoperpub"
-	consNodeAddressPrefix := app.AccountAddressPrefix + "valcons"
-	consNodePubKeyPrefix := app.AccountAddressPrefix + "valconspub"
+const (
+	// Bech32Prefix defines the Bech32 prefix used for EthAccounts
+	Bech32Prefix = "artl"
 
-	// Set and seal config
+	// Bech32PrefixAccAddr defines the Bech32 prefix of an account's address
+	Bech32PrefixAccAddr = Bech32Prefix
+	// Bech32PrefixAccPub defines the Bech32 prefix of an account's public key
+	Bech32PrefixAccPub = Bech32Prefix + sdk.PrefixPublic
+	// Bech32PrefixValAddr defines the Bech32 prefix of a validator's operator address
+	Bech32PrefixValAddr = Bech32Prefix + sdk.PrefixValidator + sdk.PrefixOperator
+	// Bech32PrefixValPub defines the Bech32 prefix of a validator's operator public key
+	Bech32PrefixValPub = Bech32Prefix + sdk.PrefixValidator + sdk.PrefixOperator + sdk.PrefixPublic
+	// Bech32PrefixConsAddr defines the Bech32 prefix of a consensus node address
+	Bech32PrefixConsAddr = Bech32Prefix + sdk.PrefixValidator + sdk.PrefixConsensus
+	// Bech32PrefixConsPub defines the Bech32 prefix of a consensus node public key
+	Bech32PrefixConsPub = Bech32Prefix + sdk.PrefixValidator + sdk.PrefixConsensus + sdk.PrefixPublic
+
+	// DisplayDenom defines the denomination displayed to users in client applications.
+	DisplayDenom = "art"
+	// BaseDenom defines artelad base denonm
+	BaseDenom = "aart"
+)
+
+// SetBech32Prefixes sets the global prefixes to be used when serializing addresses and public keys to Bech32 strings.
+func setBech32Prefixes(config *sdk.Config) {
+	config.SetBech32PrefixForAccount(Bech32PrefixAccAddr, Bech32PrefixAccPub)
+	config.SetBech32PrefixForValidator(Bech32PrefixValAddr, Bech32PrefixValPub)
+	config.SetBech32PrefixForConsensusNode(Bech32PrefixConsAddr, Bech32PrefixConsPub)
+}
+
+// SetBip44CoinType sets the global coin type to be used in hierarchical deterministic wallets.
+func setBip44CoinType(config *sdk.Config) {
+	config.SetCoinType(artelatypes.Bip44CoinType)
+	config.SetPurpose(sdk.Purpose)                        // Shared
+	config.SetFullFundraiserPath(artelatypes.BIP44HDPath) //nolint: staticcheck
+}
+
+// RegisterDenoms registers the base and display denominations to the SDK.
+func registerDenoms() {
+	if err := sdk.RegisterDenom(DisplayDenom, sdk.OneDec()); err != nil {
+		panic(err)
+	}
+
+	if err := sdk.RegisterDenom(BaseDenom, sdk.NewDecWithPrec(1, artelatypes.BaseDenomUnit)); err != nil {
+		panic(err)
+	}
+}
+
+func initSDKConfig() {
+	// set the address prefixes
 	config := sdk.GetConfig()
-	config.SetBech32PrefixForAccount(app.AccountAddressPrefix, accountPubKeyPrefix)
-	config.SetBech32PrefixForValidator(validatorAddressPrefix, validatorPubKeyPrefix)
-	config.SetBech32PrefixForConsensusNode(consNodeAddressPrefix, consNodePubKeyPrefix)
+	setBech32Prefixes(config)
+	setBip44CoinType(config)
 	config.Seal()
+
+	registerDenoms()
 }

--- a/ethereum/rpc/apis.go
+++ b/ethereum/rpc/apis.go
@@ -25,7 +25,7 @@ func GetAPIs(clientCtx client.Context, wsClient *rpcclient.WSClient, logger log.
 			Service:   ethapi.NewEthereumAPI(apiBackend),
 		}, {
 			Namespace: "eth",
-			Service:   ethapi.NewBlockChainAPI(apiBackend),
+			Service:   ethapi.NewBlockChainAPI(apiBackend, logger),
 		}, {
 			Namespace: "eth",
 			Service:   ethapi.NewTransactionAPI(apiBackend, logger, nonceLock),

--- a/ethereum/rpc/backend.go
+++ b/ethereum/rpc/backend.go
@@ -177,7 +177,10 @@ func (b *BackendImpl) RPCTxFeeCap() float64 {
 }
 
 func (b *BackendImpl) UnprotectedAllowed() bool {
-	return false
+	if b.cfg.AppCfg == nil {
+		return false
+	}
+	return b.cfg.AppCfg.JSONRPC.AllowUnprotectedTxs
 }
 
 // This is copied from filters.Backend

--- a/ethereum/rpc/config.go
+++ b/ethereum/rpc/config.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 
+	"github.com/artela-network/artela/ethereum/server/config"
 	"github.com/ethereum/go-ethereum/eth/ethconfig"
 	"github.com/ethereum/go-ethereum/eth/gasprice"
 )
@@ -34,6 +35,9 @@ func DefaultConfig() *Config {
 
 // Config represents the configurable parameters for Polaris.
 type Config struct {
+	// AppCfg preserve the server config
+	AppCfg *config.Config
+
 	// Gas Price Oracle config.
 	GPO *gasprice.Config
 

--- a/ethereum/rpc/ethapi/api.go
+++ b/ethereum/rpc/ethapi/api.go
@@ -293,12 +293,13 @@ func (s *PersonalAccountAPI) Unpair(ctx context.Context, url string, pin string)
 
 // BlockChainAPI provides an API to access Ethereum blockchain data.
 type BlockChainAPI struct {
-	b Backend
+	logger log.Logger
+	b      Backend
 }
 
 // NewBlockChainAPI creates a new Ethereum blockchain API.
-func NewBlockChainAPI(b Backend) *BlockChainAPI {
-	return &BlockChainAPI{b}
+func NewBlockChainAPI(b Backend, logger log.Logger) *BlockChainAPI {
+	return &BlockChainAPI{logger, b}
 }
 
 // ChainId is the EIP-155 replay-protection chain id for the current Ethereum chain config.
@@ -313,7 +314,11 @@ func (api *BlockChainAPI) ChainId() *hexutil.Big {
 
 // BlockNumber returns the block number of the chain head.
 func (s *BlockChainAPI) BlockNumber() hexutil.Uint64 {
-	header, _ := s.b.HeaderByNumber(context.Background(), rpc.LatestBlockNumber) // latest header should always be available
+	header, err := s.b.HeaderByNumber(context.Background(), rpc.LatestBlockNumber) // latest header should always be available
+	if err == nil || header == nil {
+		s.logger.Debug("get BlockNumber failed", err)
+		return 0
+	}
 	return hexutil.Uint64(header.Number.Uint64())
 }
 

--- a/ethereum/server/config/config.go
+++ b/ethereum/server/config/config.go
@@ -343,6 +343,7 @@ func GetConfig(v *viper.Viper) (Config, error) {
 			EnableIndexer:            v.GetBool("json-rpc.enable-indexer"),
 			MetricsAddress:           v.GetString("json-rpc.metrics-address"),
 			FixRevertGasRefundHeight: v.GetInt64("json-rpc.fix-revert-gas-refund-height"),
+			AllowUnprotectedTxs:      v.GetBool("json-rpc.allow-unprotected-txs"),
 		},
 		TLS: TLSConfig{
 			CertificatePath: v.GetString("tls.certificate-path"),

--- a/ethereum/server/config/config.go
+++ b/ethereum/server/config/config.go
@@ -11,7 +11,10 @@ import (
 	"github.com/cometbft/cometbft/libs/strings"
 
 	errorsmod "cosmossdk.io/errors"
+	clientflags "github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/server/config"
+	pruningtypes "github.com/cosmos/cosmos-sdk/store/pruning/types"
+	"github.com/cosmos/cosmos-sdk/telemetry"
 	errortypes "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
@@ -178,10 +181,83 @@ func AppConfig(denom string) (string, interface{}) {
 // DefaultConfig returns server's default configuration.
 func DefaultConfig() *Config {
 	return &Config{
-		Config:  *config.DefaultConfig(),
+		Config:  *DefaultServerConfig(),
 		EVM:     *DefaultEVMConfig(),
 		JSONRPC: *DefaultJSONRPCConfig(),
 		TLS:     *DefaultTLSConfig(),
+	}
+}
+
+// DefaultConfig returns server's default configuration.
+func DefaultServerConfig() *config.Config {
+	return &config.Config{
+		BaseConfig: config.BaseConfig{
+			MinGasPrices:        "",
+			InterBlockCache:     true,
+			Pruning:             pruningtypes.PruningOptionCustom,
+			PruningKeepRecent:   "2",
+			PruningInterval:     "10",
+			MinRetainBlocks:     0,
+			IndexEvents:         make([]string, 0),
+			IAVLCacheSize:       781250,
+			IAVLDisableFastNode: false,
+			IAVLLazyLoading:     false,
+			AppDBBackend:        "",
+		},
+		Telemetry: telemetry.Config{
+			Enabled:      false,
+			GlobalLabels: [][]string{},
+		},
+		API: config.APIConfig{
+			Enable:             false,
+			Swagger:            false,
+			Address:            config.DefaultAPIAddress,
+			MaxOpenConnections: 1000,
+			RPCReadTimeout:     10,
+			RPCMaxBodyBytes:    1000000,
+		},
+		GRPC: config.GRPCConfig{
+			Enable:         true,
+			Address:        config.DefaultGRPCAddress,
+			MaxRecvMsgSize: config.DefaultGRPCMaxRecvMsgSize,
+			MaxSendMsgSize: config.DefaultGRPCMaxSendMsgSize,
+		},
+		Rosetta: config.RosettaConfig{
+			Enable:              false,
+			Address:             ":8080",
+			Blockchain:          "app",
+			Network:             "network",
+			Retries:             3,
+			Offline:             false,
+			EnableFeeSuggestion: false,
+			GasToSuggest:        clientflags.DefaultGasLimit,
+			DenomToSuggest:      "uatom",
+		},
+		GRPCWeb: config.GRPCWebConfig{
+			Enable:  true,
+			Address: config.DefaultGRPCWebAddress,
+		},
+		StateSync: config.StateSyncConfig{
+			SnapshotInterval:   0,
+			SnapshotKeepRecent: 2,
+		},
+		Store: config.StoreConfig{
+			Streamers: []string{},
+		},
+		Streamers: config.StreamersConfig{
+			File: config.FileStreamerConfig{
+				Keys:            []string{"*"},
+				WriteDir:        "",
+				OutputMetadata:  true,
+				StopNodeOnError: true,
+				// NOTICE: The default config doesn't protect the streamer data integrity
+				// in face of system crash.
+				Fsync: false,
+			},
+		},
+		Mempool: config.MempoolConfig{
+			MaxTxs: 5_000,
+		},
 	}
 }
 

--- a/ethereum/server/start.go
+++ b/ethereum/server/start.go
@@ -469,7 +469,7 @@ func startInProcess(ctx *sdkserver.Context, clientCtx client.Context, appCreator
 
 		go func() {
 			// wait for the start of the RPC server.
-			time.Sleep(4 * time.Second)
+			time.Sleep(8 * time.Second)
 			if err := jsonrpcSrv.Start(); err != nil {
 				errCh <- err
 			}

--- a/ethereum/server/util.go
+++ b/ethereum/server/util.go
@@ -68,6 +68,7 @@ func CreateJSONRPC(ctx *server.Context,
 	cfg.RPCGasCap = config.JSONRPC.GasCap
 	cfg.RPCEVMTimeout = config.JSONRPC.EVMTimeout
 	cfg.RPCTxFeeCap = config.JSONRPC.TxFeeCap
+	cfg.AppCfg = config
 
 	nodeCfg := rpc2.DefaultGethNodeConfig()
 	address := strings.Split(config.JSONRPC.Address, ":")

--- a/scripts/start-artela.sh
+++ b/scripts/start-artela.sh
@@ -3,10 +3,11 @@
 DATA_DIR="$HOME/.artelad"
 
 sed -i 's/127.0.0.1:8545/0.0.0.0:8545/g' $DATA_DIR/config/app.toml
+sed -i 's/timeout_commit = \"5s\"/timeout_commit = \"1s\"/g' $DATA_DIR/config/config.toml
 sed -i 's/"extra_eips": \[\]/"extra_eips": \[3855\]/g' $DATA_DIR/config/genesis.json
 
 echo "starting artela node $i in background ..."
-./artelad start --pruning=nothing \
+./artelad start \
 --log_level debug \
 --minimum-gas-prices=0.0001art \
 --api.enable \

--- a/x/evm/txs/tx_legacy.go
+++ b/x/evm/txs/tx_legacy.go
@@ -6,8 +6,6 @@ import (
 	artela "github.com/artela-network/artela/ethereum/types"
 	"github.com/artela-network/artela/x/evm/types"
 
-	errortypes "github.com/cosmos/cosmos-sdk/types/errors"
-
 	errorsmod "cosmossdk.io/errors"
 	"github.com/ethereum/go-ethereum/common"
 	ethereum "github.com/ethereum/go-ethereum/core/types"
@@ -95,15 +93,6 @@ func (tx LegacyTx) Validate() error {
 		if err := artela.ValidateAddress(tx.To); err != nil {
 			return errorsmod.Wrap(err, "invalid to address")
 		}
-	}
-
-	chainID := tx.GetChainID()
-
-	if chainID == nil {
-		return errorsmod.Wrap(
-			errortypes.ErrInvalidChainID,
-			"chain ID must be present on AccessList txs",
-		)
 	}
 
 	return nil

--- a/x/evm/txs/tx_legacy.go
+++ b/x/evm/txs/tx_legacy.go
@@ -106,13 +106,6 @@ func (tx LegacyTx) Validate() error {
 		)
 	}
 
-	if !(chainID.Cmp(big.NewInt(11820)) == 0 || chainID.Cmp(big.NewInt(11821)) == 0) {
-		return errorsmod.Wrapf(
-			errortypes.ErrInvalidChainID,
-			"chain ID must be 11820 or 11821 on Artela, got %s", chainID,
-		)
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
1. Fixed a legacy transaction validation failure.
2. Resolved an issue where nodes could fail to start when the wallet was connecting to the JSON-RPC.
3. Adjusted the default pruning settings for testnet creation.