### PR TITLE
fix: fix gas estimation inaccuracy

### DIFF
--- a/x/evm/artela/contract/handlers.go
+++ b/x/evm/artela/contract/handlers.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/holiman/uint256"
 	"math/big"
+	"time"
 )
 
 var (
@@ -719,15 +720,19 @@ func isAspectDeployed(ctx sdk.Context, store *AspectStore, aspectId common.Addre
 }
 
 func validateCode(ctx sdk.Context, aspectCode []byte) error {
+	startTime := time.Now()
 	validator, err := runtime.NewValidator(ctx, ctx.Logger(), runtime.WASM)
 	if err != nil {
 		return err
 	}
+	ctx.Logger().Info("validated aspect bytecode", "duration", time.Since(startTime).String())
 
+	startTime = time.Now()
 	parsed, err := ParseByteCode(aspectCode)
 	if err != nil {
 		return err
 	}
+	ctx.Logger().Info("parsed aspect bytecode", "duration", time.Since(startTime).String())
 
 	return validator.Validate(parsed)
 }

--- a/x/evm/keeper/evm.go
+++ b/x/evm/keeper/evm.go
@@ -176,7 +176,7 @@ func (k *Keeper) ApplyTransaction(ctx cosmos.Context, tx *ethereum.Transaction) 
 	}
 
 	// pass true to commit the StateDB
-	res, err := k.ApplyMessageWithConfig(tmpCtx, aspectCtx, msg, nil, true, evmConfig, txConfig)
+	res, err := k.ApplyMessageWithConfig(tmpCtx, aspectCtx, msg, nil, true, evmConfig, txConfig, k.isCustomizedVerification(tx))
 	if err != nil {
 		ctx.Logger().Error("ApplyMessageWithConfig with error", "txhash", tx.Hash().String(), "error", err, "response", res)
 		return nil, errorsmod.Wrap(err, "failed to apply ethereum core message")
@@ -271,7 +271,7 @@ func (k *Keeper) ApplyMessage(ctx cosmos.Context, msg *core.Message, tracer vm.E
 		return nil, errors.New("ApplyMessageWithConfig: unwrap AspectRuntimeContext failed")
 	}
 
-	return k.ApplyMessageWithConfig(ctx, aspectCtx, msg, tracer, commit, evmConfig, txConfig)
+	return k.ApplyMessageWithConfig(ctx, aspectCtx, msg, tracer, commit, evmConfig, txConfig, false)
 }
 
 // ApplyMessageWithConfig computes the new states by applying the given message against the existing states.
@@ -319,6 +319,7 @@ func (k *Keeper) ApplyMessageWithConfig(ctx cosmos.Context,
 	commit bool,
 	cfg *states.EVMConfig,
 	txConfig states.TxConfig,
+	isCustomVerification bool,
 ) (*txs.MsgEthereumTxResponse, error) {
 	var (
 		ret   []byte // return bytes from evm execution
@@ -361,7 +362,7 @@ func (k *Keeper) ApplyMessageWithConfig(ctx cosmos.Context,
 	contractCreation := msg.To == nil
 	isLondon := cfg.ChainConfig.IsLondon(evm.Context.BlockNumber)
 
-	intrinsicGas, err := k.GetEthIntrinsicGas(ctx, msg, cfg.ChainConfig, contractCreation)
+	intrinsicGas, err := k.GetEthIntrinsicGas(ctx, msg, cfg.ChainConfig, contractCreation, isCustomVerification)
 	if err != nil {
 		// should have already been checked on Ante Handler
 		return nil, errorsmod.Wrap(err, "intrinsic gas failed")

--- a/x/evm/keeper/grpc_query.go
+++ b/x/evm/keeper/grpc_query.go
@@ -262,7 +262,8 @@ func (k Keeper) EthCall(c context.Context, req *txs.EthCallRequest) (*txs.MsgEth
 	defer aspectCtx.Destroy()
 
 	// pass false to not commit StateDB
-	res, err := k.ApplyMessageWithConfig(ctx, aspectCtx, msg, nil, false, cfg, txConfig)
+	isCustomVerification := len(args.GetValidationData()) > 0
+	res, err := k.ApplyMessageWithConfig(ctx, aspectCtx, msg, nil, false, cfg, txConfig, isCustomVerification)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
@@ -339,6 +340,8 @@ func (k Keeper) EstimateGas(c context.Context, req *txs.EthCallRequest) (*txs.Es
 	// NOTE: the errors from the executable below should be consistent with go-ethereum,
 	// so we don't wrap them with the gRPC status code
 
+	isCustomVerification := len(args.GetValidationData()) > 0
+
 	// Create a helper to check if a gas allowance results in an executable txs
 	executable := func(gas uint64) (vmError bool, rsp *txs.MsgEthereumTxResponse, err error) {
 		// need to create a cache context here to avoid state change affecting each other
@@ -353,7 +356,7 @@ func (k Keeper) EstimateGas(c context.Context, req *txs.EthCallRequest) (*txs.Es
 		// update the message with the new gas value
 		msg.GasLimit = gas
 		// pass false to not commit StateDB
-		rsp, err = k.ApplyMessageWithConfig(cosmosCtx, aspectCtx, msg, nil, false, cfg, txConfig)
+		rsp, err = k.ApplyMessageWithConfig(cosmosCtx, aspectCtx, msg, nil, false, cfg, txConfig, isCustomVerification)
 		if err != nil {
 			if errors.Is(err, core.ErrIntrinsicGas) {
 				return true, nil, nil // Special case, raise gas limit
@@ -441,7 +444,8 @@ func (k Keeper) TraceTx(c context.Context, req *txs.QueryTraceTxRequest) (*txs.Q
 		txConfig.TxHash = ethTx.Hash()
 		txConfig.TxIndex = uint(i)
 
-		rsp, err := k.ApplyMessageWithConfig(ctx, aspectCtx, msg, txs.NewNoOpTracer(), true, cfg, txConfig)
+		isCustomVerification := k.isCustomizedVerification(ethTx)
+		rsp, err := k.ApplyMessageWithConfig(ctx, aspectCtx, msg, txs.NewNoOpTracer(), true, cfg, txConfig, isCustomVerification)
 		if err != nil {
 			continue
 		}
@@ -626,7 +630,8 @@ func (k *Keeper) traceTx(
 		}
 	}()
 
-	res, err := k.ApplyMessageWithConfig(ctx, aspectCtx, msg, tracer, commitMessage, cfg, txConfig)
+	isCustomVerification := k.isCustomizedVerification(tx)
+	res, err := k.ApplyMessageWithConfig(ctx, aspectCtx, msg, tracer, commitMessage, cfg, txConfig, isCustomVerification)
 	if err != nil {
 		return nil, 0, status.Error(codes.Internal, err.Error())
 	}


### PR DESCRIPTION
Currently, the gas consumption of our tx verifier cannot be included in the execution costs because it involves the transfer of data inside and outside the consensus state, which is very complicated.

Therefore, we have set a rule: the maximum gas consumption for tx verification is 150,000, with the session key used as a reference value, approximately consuming around 77,000.

If it is a custom-verified transaction, this 150,000 gas will be counted as the intrinsic gas of the transaction.