### PR TITLE
fix/format imports

### DIFF
--- a/app/ante/cosmos/msg_checker.go
+++ b/app/ante/cosmos/msg_checker.go
@@ -2,9 +2,10 @@ package cosmos
 
 import (
 	errorsmod "cosmossdk.io/errors"
-	evmmodule "github.com/artela-network/artela/x/evm/txs"
 	cosmos "github.com/cosmos/cosmos-sdk/types"
 	errortypes "github.com/cosmos/cosmos-sdk/types/errors"
+
+	evmmodule "github.com/artela-network/artela/x/evm/txs"
 )
 
 // RejectMessagesDecorator prevents invalid msg types from being executed

--- a/app/ante/cosmos/sig_checker.go
+++ b/app/ante/cosmos/sig_checker.go
@@ -3,8 +3,6 @@ package cosmos
 import (
 	"fmt"
 
-	artela "github.com/artela-network/artela/ethereum/types"
-
 	errorsmod "cosmossdk.io/errors"
 
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -22,7 +20,7 @@ import (
 
 	"github.com/artela-network/artela/ethereum/crypto/ethsecp256k1"
 	"github.com/artela-network/artela/ethereum/eip712"
-
+	artela "github.com/artela-network/artela/ethereum/types"
 	evmmodule "github.com/artela-network/artela/x/evm/types"
 )
 

--- a/app/ante/decorator.go
+++ b/app/ante/decorator.go
@@ -1,10 +1,8 @@
 package ante
 
 import (
-	"github.com/artela-network/artela/x/evm/txs"
-	"github.com/cosmos/cosmos-sdk/baseapp"
-
 	errorsmod "cosmossdk.io/errors"
+	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/codec"
 	cosmos "github.com/cosmos/cosmos-sdk/types"
 	errortypes "github.com/cosmos/cosmos-sdk/types/errors"
@@ -12,18 +10,17 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/auth/ante"
 	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
 	authmodule "github.com/cosmos/cosmos-sdk/x/auth/types"
+	sdkvesting "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
 	ibcante "github.com/cosmos/ibc-go/v7/modules/core/ante"
 	ibckeeper "github.com/cosmos/ibc-go/v7/modules/core/keeper"
 
-	anteutils "github.com/artela-network/artela/app/ante/utils"
-	"github.com/artela-network/artela/app/interfaces"
-
 	cosmosante "github.com/artela-network/artela/app/ante/cosmos"
 	evmante "github.com/artela-network/artela/app/ante/evm"
+	anteutils "github.com/artela-network/artela/app/ante/utils"
+	"github.com/artela-network/artela/app/interfaces"
+	"github.com/artela-network/artela/x/evm/txs"
 	evmmodule "github.com/artela-network/artela/x/evm/types"
-
 	// vestingtypes "github.com/artela-network/artela/x/vesting/types"
-	sdkvesting "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
 )
 
 // AnteDecorators defines the list of module keepers required to run the Artela

--- a/app/ante/evm/aspect_context.go
+++ b/app/ante/evm/aspect_context.go
@@ -1,19 +1,21 @@
 package evm
 
 import (
-	errorsmod "cosmossdk.io/errors"
 	"fmt"
-	"github.com/artela-network/artela/x/evm/artela/provider"
-	"github.com/artela-network/artela/x/evm/states"
-	inherent "github.com/artela-network/aspect-core/chaincoreext/jit_inherent"
+
+	errorsmod "cosmossdk.io/errors"
+
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	cosmos "github.com/cosmos/cosmos-sdk/types"
 	errortypes "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/artela-network/artela/app/interfaces"
+	"github.com/artela-network/artela/x/evm/artela/provider"
 	"github.com/artela-network/artela/x/evm/artela/types"
+	"github.com/artela-network/artela/x/evm/states"
 	"github.com/artela-network/artela/x/evm/txs"
+	inherent "github.com/artela-network/aspect-core/chaincoreext/jit_inherent"
 )
 
 // CreateAspectRuntimeContextDecorator prepare the aspect runtime context

--- a/app/ante/evm/basic_checker.go
+++ b/app/ante/evm/basic_checker.go
@@ -6,19 +6,18 @@ import (
 
 	errorsmod "cosmossdk.io/errors"
 	sdkmath "cosmossdk.io/math"
-	"github.com/artela-network/artela/app/interfaces"
-	artela "github.com/artela-network/artela/ethereum/types"
-	"github.com/artela-network/artela/x/evm/txs"
-	"github.com/artela-network/artela/x/evm/txs/support"
 	cosmos "github.com/cosmos/cosmos-sdk/types"
 	errortypes "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/ethereum/go-ethereum/common"
 
 	anteutils "github.com/artela-network/artela/app/ante/utils"
+	"github.com/artela-network/artela/app/interfaces"
+	artela "github.com/artela-network/artela/ethereum/types"
 	"github.com/artela-network/artela/x/evm/keeper"
 	"github.com/artela-network/artela/x/evm/states"
+	"github.com/artela-network/artela/x/evm/txs"
+	"github.com/artela-network/artela/x/evm/txs/support"
 	evmmodule "github.com/artela-network/artela/x/evm/types"
-
-	"github.com/ethereum/go-ethereum/common"
 )
 
 // EthAccountVerificationDecorator validates an account balance checks

--- a/app/ante/evm/context_checker.go
+++ b/app/ante/evm/context_checker.go
@@ -4,8 +4,6 @@ import (
 	"errors"
 	"strconv"
 
-	"github.com/artela-network/artela/x/evm/txs"
-
 	errorsmod "cosmossdk.io/errors"
 	sdkmath "cosmossdk.io/math"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
@@ -15,6 +13,7 @@ import (
 	ethereum "github.com/ethereum/go-ethereum/core/types"
 
 	"github.com/artela-network/artela/app/interfaces"
+	"github.com/artela-network/artela/x/evm/txs"
 	evmmodule "github.com/artela-network/artela/x/evm/types"
 )
 

--- a/app/ante/evm/fee_checker.go
+++ b/app/ante/evm/fee_checker.go
@@ -3,18 +3,16 @@ package evm
 import (
 	"math"
 
-	artela "github.com/artela-network/artela/ethereum/types"
-	"github.com/artela-network/artela/x/evm/txs"
-
 	errorsmod "cosmossdk.io/errors"
 	sdkmath "cosmossdk.io/math"
-
 	cosmos "github.com/cosmos/cosmos-sdk/types"
 	errortypes "github.com/cosmos/cosmos-sdk/types/errors"
 	authante "github.com/cosmos/cosmos-sdk/x/auth/ante"
 
 	anteutils "github.com/artela-network/artela/app/ante/utils"
 	"github.com/artela-network/artela/app/interfaces"
+	artela "github.com/artela-network/artela/ethereum/types"
+	"github.com/artela-network/artela/x/evm/txs"
 )
 
 // NewDynamicFeeChecker returns a `TxFeeChecker` that applies a dynamic fee to

--- a/app/ante/evm/gaswanted_checker.go
+++ b/app/ante/evm/gaswanted_checker.go
@@ -3,12 +3,12 @@ package evm
 import (
 	"math/big"
 
-	"github.com/artela-network/artela/app/interfaces"
-	"github.com/artela-network/artela/ethereum/types"
-
 	errorsmod "cosmossdk.io/errors"
 	cosmos "github.com/cosmos/cosmos-sdk/types"
 	errortypes "github.com/cosmos/cosmos-sdk/types/errors"
+
+	"github.com/artela-network/artela/app/interfaces"
+	"github.com/artela-network/artela/ethereum/types"
 )
 
 // GasWantedDecorator keeps track of the gasWanted amount on the current block in transient store

--- a/app/ante/evm/sig_checker.go
+++ b/app/ante/evm/sig_checker.go
@@ -1,13 +1,13 @@
 package evm
 
 import (
-	"github.com/artela-network/artela/app/interfaces"
-	"github.com/artela-network/artela/x/evm/txs"
-	"github.com/cosmos/cosmos-sdk/baseapp"
-
 	errorsmod "cosmossdk.io/errors"
+	"github.com/cosmos/cosmos-sdk/baseapp"
 	cosmos "github.com/cosmos/cosmos-sdk/types"
 	errortypes "github.com/cosmos/cosmos-sdk/types/errors"
+
+	"github.com/artela-network/artela/app/interfaces"
+	"github.com/artela-network/artela/x/evm/txs"
 )
 
 // EthSigVerificationDecorator validates an ethereum signatures

--- a/app/app.go
+++ b/app/app.go
@@ -122,8 +122,6 @@ import (
 
 	// this line is used by starport scaffolding # stargate/app/moduleImport
 
-	aspecttypes "github.com/artela-network/aspect-core/types"
-
 	"github.com/artela-network/artela/app/ante"
 	ethante "github.com/artela-network/artela/app/ante/evm"
 	appparams "github.com/artela-network/artela/app/params"
@@ -132,6 +130,7 @@ import (
 	"github.com/artela-network/artela/docs"
 	srvflags "github.com/artela-network/artela/ethereum/server/flags"
 	artela "github.com/artela-network/artela/ethereum/types"
+	aspecttypes "github.com/artela-network/aspect-core/types"
 
 	// do not remove this, this will register the native evm tracers
 	_ "github.com/artela-network/artela-evm/tracers/native"

--- a/app/codec.go
+++ b/app/codec.go
@@ -1,12 +1,13 @@
 package app
 
 import (
-	codec2 "github.com/artela-network/artela/ethereum/crypto/codec"
-	"github.com/artela-network/artela/ethereum/types"
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/std"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	codec2 "github.com/artela-network/artela/ethereum/crypto/codec"
+	"github.com/artela-network/artela/ethereum/types"
 )
 
 // RegisterLegacyAminoCodec registers Interfaces from types, crypto, and SDK std.

--- a/app/interfaces/interfaces.go
+++ b/app/interfaces/interfaces.go
@@ -3,19 +3,16 @@ package interfaces
 import (
 	"math/big"
 
-	artvmtype "github.com/artela-network/artela/x/evm/artela/types"
-
-	ethereum "github.com/ethereum/go-ethereum/core/types"
-
-	"github.com/artela-network/artela/x/evm/states"
-
 	"github.com/artela-network/artela-evm/vm"
 	cosmos "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/tx"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
+	ethereum "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
 
+	artvmtype "github.com/artela-network/artela/x/evm/artela/types"
+	"github.com/artela-network/artela/x/evm/states"
 	evmtypes "github.com/artela-network/artela/x/evm/txs/support"
 	feemodule "github.com/artela-network/artela/x/fee/types"
 )

--- a/app/post/decorator.go
+++ b/app/post/decorator.go
@@ -3,9 +3,9 @@ package post
 import (
 	errorsmod "cosmossdk.io/errors"
 	"github.com/cosmos/cosmos-sdk/baseapp"
+	cosmos "github.com/cosmos/cosmos-sdk/types"
 	errortypes "github.com/cosmos/cosmos-sdk/types/errors"
 
-	cosmos "github.com/cosmos/cosmos-sdk/types"
 	// vestingtypes "github.com/artela-network/artela/x/vesting/types"
 	"github.com/artela-network/artela/app/interfaces"
 	evmpost "github.com/artela-network/artela/app/post/evm"

--- a/client/config.go
+++ b/client/config.go
@@ -5,14 +5,13 @@ import (
 	"os"
 	"path"
 
-	"github.com/artela-network/artela/ethereum/types"
-
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
 	"github.com/cometbft/cometbft/libs/cli"
-
 	"github.com/cosmos/cosmos-sdk/client/flags"
+
+	"github.com/artela-network/artela/ethereum/types"
 )
 
 // InitConfig adds the chain-id, encoding and output flags to the persistent flag set.

--- a/client/export.go
+++ b/client/export.go
@@ -5,17 +5,17 @@ import (
 	"fmt"
 	"strings"
 
-	ethsecp256k12 "github.com/artela-network/artela/ethereum/crypto/ethsecp256k1"
-	"github.com/artela-network/artela/ethereum/crypto/hd"
+	"github.com/spf13/cobra"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/input"
 	"github.com/cosmos/cosmos-sdk/crypto"
+	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	ethcrypto "github.com/ethereum/go-ethereum/crypto"
-	"github.com/spf13/cobra"
 
-	"github.com/cosmos/cosmos-sdk/crypto/keyring"
+	ethsecp256k12 "github.com/artela-network/artela/ethereum/crypto/ethsecp256k1"
+	"github.com/artela-network/artela/ethereum/crypto/hd"
 )
 
 // UnsafeExportEthKeyCommand exports a key with the given name as a private key in hex format.

--- a/client/import.go
+++ b/client/import.go
@@ -3,15 +3,15 @@ package client
 import (
 	"bufio"
 
-	"github.com/artela-network/artela/ethereum/crypto/ethsecp256k1"
-	"github.com/artela-network/artela/ethereum/crypto/hd"
-
 	"github.com/spf13/cobra"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/input"
 	"github.com/cosmos/cosmos-sdk/crypto"
 	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/artela-network/artela/ethereum/crypto/ethsecp256k1"
+	"github.com/artela-network/artela/ethereum/crypto/hd"
 )
 
 // UnsafeImportKeyCommand imports private keys from a keyfile.

--- a/client/keys.go
+++ b/client/keys.go
@@ -3,18 +3,17 @@ package client
 import (
 	"bufio"
 
-	"github.com/artela-network/artela/ethereum/crypto/ethsecp256k1"
-	"github.com/artela-network/artela/ethereum/crypto/hd"
+	"github.com/spf13/cobra"
 
 	"github.com/cometbft/cometbft/libs/cli"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/keys"
-	"github.com/spf13/cobra"
-
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 
 	clientkeys "github.com/artela-network/artela/client/keys"
+	"github.com/artela-network/artela/ethereum/crypto/ethsecp256k1"
+	"github.com/artela-network/artela/ethereum/crypto/hd"
 )
 
 // KeyCommands registers a sub-tree of commands to interact with

--- a/client/keys/add.go
+++ b/client/keys/add.go
@@ -7,10 +7,6 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/artela-network/artela/ethereum/crypto/codec"
-	"github.com/artela-network/artela/ethereum/crypto/ethsecp256k1"
-	cryptohd "github.com/artela-network/artela/ethereum/crypto/hd"
-
 	"github.com/cosmos/go-bip39"
 	"github.com/spf13/cobra"
 
@@ -23,6 +19,10 @@ import (
 	"github.com/cosmos/cosmos-sdk/crypto/keys/multisig"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/artela-network/artela/ethereum/crypto/codec"
+	"github.com/artela-network/artela/ethereum/crypto/ethsecp256k1"
+	cryptohd "github.com/artela-network/artela/ethereum/crypto/hd"
 )
 
 const (

--- a/client/keys/utils.go
+++ b/client/keys/utils.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/artela-network/artela/ethereum/crypto/codec"
-
 	"sigs.k8s.io/yaml"
 
 	cryptokeyring "github.com/cosmos/cosmos-sdk/crypto/keyring"
+
+	"github.com/artela-network/artela/ethereum/crypto/codec"
 )
 
 // available output formats.

--- a/client/testnet.go
+++ b/client/testnet.go
@@ -10,22 +10,12 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/artela-network/artela/ethereum/crypto/ethsecp256k1"
-	"github.com/artela-network/artela/ethereum/crypto/hd"
-	"github.com/artela-network/artela/ethereum/server/config"
-	srvflags "github.com/artela-network/artela/ethereum/server/flags"
-	types2 "github.com/artela-network/artela/ethereum/types"
-	"github.com/artela-network/artela/x/evm/txs"
-	"github.com/artela-network/artela/x/evm/txs/support"
-
-	"github.com/ethereum/go-ethereum/common"
+	"github.com/spf13/cobra"
 
 	tmconfig "github.com/cometbft/cometbft/config"
 	tmrand "github.com/cometbft/cometbft/libs/rand"
 	"github.com/cometbft/cometbft/types"
 	tmtime "github.com/cometbft/cometbft/types/time"
-	"github.com/spf13/cobra"
-
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
@@ -45,8 +35,16 @@ import (
 	govv1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 	mintypes "github.com/cosmos/cosmos-sdk/x/mint/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"github.com/ethereum/go-ethereum/common"
 
+	"github.com/artela-network/artela/ethereum/crypto/ethsecp256k1"
+	"github.com/artela-network/artela/ethereum/crypto/hd"
+	"github.com/artela-network/artela/ethereum/server/config"
+	srvflags "github.com/artela-network/artela/ethereum/server/flags"
+	types2 "github.com/artela-network/artela/ethereum/types"
 	"github.com/artela-network/artela/testutil/network"
+	"github.com/artela-network/artela/x/evm/txs"
+	"github.com/artela-network/artela/x/evm/txs/support"
 	evmtypes "github.com/artela-network/artela/x/evm/types"
 )
 

--- a/cmd/artelad/cmd/genaccounts.go
+++ b/cmd/artelad/cmd/genaccounts.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/artela-network/artela/ethereum/crypto/hd"
+	"github.com/spf13/cobra"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
@@ -18,7 +18,8 @@ import (
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/cosmos/cosmos-sdk/x/genutil"
 	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
-	"github.com/spf13/cobra"
+
+	"github.com/artela-network/artela/ethereum/crypto/hd"
 )
 
 const (

--- a/cmd/artelad/cmd/gencontract.go
+++ b/cmd/artelad/cmd/gencontract.go
@@ -7,13 +7,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/spf13/cobra"
-
-	ethtypes "github.com/artela-network/artela/ethereum/types"
-	evmstate "github.com/artela-network/artela/x/evm/txs/support"
-	evmtypes "github.com/artela-network/artela/x/evm/types"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
@@ -23,6 +17,12 @@ import (
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/cosmos/cosmos-sdk/x/genutil"
 	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/crypto"
+
+	ethtypes "github.com/artela-network/artela/ethereum/types"
+	evmstate "github.com/artela-network/artela/x/evm/txs/support"
+	evmtypes "github.com/artela-network/artela/x/evm/types"
 )
 
 // AddGenesisContractCmd returns add-genesis-contract cobra Command.

--- a/cmd/artelad/cmd/keyinfo.go
+++ b/cmd/artelad/cmd/keyinfo.go
@@ -8,11 +8,12 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/spf13/cobra"
+
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	"github.com/cosmos/cosmos-sdk/version"
 	jose "github.com/dvsekhvalnov/jose2go"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/spf13/cobra"
 )
 
 const (

--- a/cmd/artelad/cmd/root.go
+++ b/cmd/artelad/cmd/root.go
@@ -7,12 +7,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	artclient "github.com/artela-network/artela/client"
-	server2 "github.com/artela-network/artela/ethereum/server"
-	config2 "github.com/artela-network/artela/ethereum/server/config"
-
-	artelakeyring "github.com/artela-network/artela/ethereum/crypto/keyring"
-	"github.com/artela-network/artela/ethereum/eip712"
+	"github.com/spf13/cast"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
 	dbm "github.com/cometbft/cometbft-db"
 	tmcfg "github.com/cometbft/cometbft/config"
@@ -38,15 +35,17 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/crisis"
 	genutilcli "github.com/cosmos/cosmos-sdk/x/genutil/client/cli"
 	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
-	"github.com/spf13/cast"
-	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 
 	// this line is used by starport scaffolding # root/moduleImport
 
 	"github.com/artela-network/artela/app"
 	appparams "github.com/artela-network/artela/app/params"
+	artclient "github.com/artela-network/artela/client"
 	"github.com/artela-network/artela/client/debug"
+	artelakeyring "github.com/artela-network/artela/ethereum/crypto/keyring"
+	"github.com/artela-network/artela/ethereum/eip712"
+	server2 "github.com/artela-network/artela/ethereum/server"
+	config2 "github.com/artela-network/artela/ethereum/server/config"
 )
 
 // NewRootCmd creates a new root command for a Cosmos SDK application

--- a/cmd/artelad/cmd/testnet.go
+++ b/cmd/artelad/cmd/testnet.go
@@ -10,13 +10,12 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/spf13/cobra"
+
 	tmconfig "github.com/cometbft/cometbft/config"
 	tmrand "github.com/cometbft/cometbft/libs/rand"
 	"github.com/cometbft/cometbft/types"
 	tmtime "github.com/cometbft/cometbft/types/time"
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/spf13/cobra"
-
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
@@ -35,19 +34,18 @@ import (
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	govv1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/artela-network/artela/ethereum/crypto/hd"
+	artelakeyring "github.com/artela-network/artela/ethereum/crypto/keyring"
 	"github.com/artela-network/artela/ethereum/server/config"
 	srvflags "github.com/artela-network/artela/ethereum/server/flags"
-
 	artelatypes "github.com/artela-network/artela/ethereum/types"
+	"github.com/artela-network/artela/ethereum/utils"
+	"github.com/artela-network/artela/testutil/network"
 	"github.com/artela-network/artela/x/evm/txs"
 	"github.com/artela-network/artela/x/evm/txs/support"
 	evmtypes "github.com/artela-network/artela/x/evm/types"
-
-	artelakeyring "github.com/artela-network/artela/ethereum/crypto/keyring"
-	"github.com/artela-network/artela/ethereum/utils"
-	"github.com/artela-network/artela/testutil/network"
 )
 
 var (

--- a/common/logger.go
+++ b/common/logger.go
@@ -1,8 +1,9 @@
 package common
 
 import (
-	"github.com/artela-network/aspect-runtime/types"
 	"github.com/cometbft/cometbft/libs/log"
+
+	"github.com/artela-network/aspect-runtime/types"
 )
 
 var _ types.Logger = (*runtimeLoggerWrapper)(nil)

--- a/ethereum/crypto/codec/amino.go
+++ b/ethereum/crypto/codec/amino.go
@@ -1,11 +1,12 @@
 package codec
 
 import (
-	ethsecp256k12 "github.com/artela-network/artela/ethereum/crypto/ethsecp256k1"
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/codec/legacy"
 	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
+
+	ethsecp256k12 "github.com/artela-network/artela/ethereum/crypto/ethsecp256k1"
 )
 
 var KeysCdc *codec.LegacyAmino

--- a/ethereum/crypto/codec/codec.go
+++ b/ethereum/crypto/codec/codec.go
@@ -1,9 +1,10 @@
 package codec
 
 import (
-	"github.com/artela-network/artela/ethereum/crypto/ethsecp256k1"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
+
+	"github.com/artela-network/artela/ethereum/crypto/ethsecp256k1"
 )
 
 // RegisterInterfaces register the Artela key concrete types.

--- a/ethereum/crypto/ethsecp256k1/ethsecp256k1.go
+++ b/ethereum/crypto/ethsecp256k1/ethsecp256k1.go
@@ -7,12 +7,13 @@ import (
 	"fmt"
 
 	errorsmod "cosmossdk.io/errors"
-	"github.com/artela-network/artela/ethereum/eip712"
 	tmcrypto "github.com/cometbft/cometbft/crypto"
 	"github.com/cosmos/cosmos-sdk/codec"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	errortypes "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/ethereum/go-ethereum/crypto"
+
+	"github.com/artela-network/artela/ethereum/eip712"
 )
 
 const (

--- a/ethereum/crypto/hd/algorithm.go
+++ b/ethereum/crypto/hd/algorithm.go
@@ -1,17 +1,17 @@
 package hd
 
 import (
-	ethsecp256k12 "github.com/artela-network/artela/ethereum/crypto/ethsecp256k1"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcutil/hdkeychain"
 	bip39 "github.com/tyler-smith/go-bip39"
 
-	"github.com/ethereum/go-ethereum/accounts"
-	"github.com/ethereum/go-ethereum/crypto"
-
 	"github.com/cosmos/cosmos-sdk/crypto/hd"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
+	"github.com/ethereum/go-ethereum/accounts"
+	"github.com/ethereum/go-ethereum/crypto"
+
+	ethsecp256k12 "github.com/artela-network/artela/ethereum/crypto/ethsecp256k1"
 )
 
 const (

--- a/ethereum/crypto/hd/algorithm_test.go
+++ b/ethereum/crypto/hd/algorithm_test.go
@@ -5,16 +5,16 @@ import (
 	"strings"
 	"testing"
 
-	artelatypes "github.com/artela-network/artela/ethereum/types"
+	"github.com/stretchr/testify/require"
 
 	amino "github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/stretchr/testify/require"
 
 	"github.com/artela-network/artela/app"
 	cryptocodec "github.com/artela-network/artela/ethereum/crypto/codec"
+	artelatypes "github.com/artela-network/artela/ethereum/types"
 )
 
 var TestCodec amino.Codec

--- a/ethereum/crypto/hd/benchmark_test.go
+++ b/ethereum/crypto/hd/benchmark_test.go
@@ -3,9 +3,9 @@ package hd
 import (
 	"testing"
 
-	"github.com/artela-network/artela/ethereum/types"
-
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
+
+	"github.com/artela-network/artela/ethereum/types"
 )
 
 func BenchmarkEthSecp256k1Algo_Derive(b *testing.B) {

--- a/ethereum/crypto/hd/utils_test.go
+++ b/ethereum/crypto/hd/utils_test.go
@@ -7,13 +7,13 @@ import (
 	"os"
 	"sync"
 
-	"github.com/ethereum/go-ethereum/accounts"
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/crypto"
-
 	"github.com/btcsuite/btcd/btcutil/hdkeychain"
 	"github.com/btcsuite/btcd/chaincfg"
 	bip39 "github.com/tyler-smith/go-bip39"
+
+	"github.com/ethereum/go-ethereum/accounts"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 )
 
 const issue179FixEnvar = "GO_ETHEREUM_HDWALLET_FIX_ISSUE_179"

--- a/ethereum/crypto/keyring/options.go
+++ b/ethereum/crypto/keyring/options.go
@@ -1,10 +1,11 @@
 package keyring
 
 import (
-	"github.com/artela-network/artela/ethereum/crypto/ethsecp256k1"
-	"github.com/artela-network/artela/ethereum/crypto/hd"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	"github.com/cosmos/cosmos-sdk/crypto/types"
+
+	"github.com/artela-network/artela/ethereum/crypto/ethsecp256k1"
+	"github.com/artela-network/artela/ethereum/crypto/hd"
 )
 
 // AppName defines the Ledger app used for signing. Artela uses the Ethereum app

--- a/ethereum/eip712/eip712_legacy.go
+++ b/ethereum/eip712/eip712_legacy.go
@@ -14,7 +14,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	errortypes "github.com/cosmos/cosmos-sdk/types/errors"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/signer/core/apitypes"

--- a/ethereum/eip712/encoding.go
+++ b/ethereum/eip712/encoding.go
@@ -4,18 +4,14 @@ import (
 	"errors"
 	"fmt"
 
-	artelatypes "github.com/artela-network/artela/ethereum/types"
-
-	"github.com/cosmos/cosmos-sdk/x/auth/migrations/legacytx"
-
+	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	txTypes "github.com/cosmos/cosmos-sdk/types/tx"
-
+	"github.com/cosmos/cosmos-sdk/x/auth/migrations/legacytx"
 	"github.com/ethereum/go-ethereum/signer/core/apitypes"
 
 	"github.com/artela-network/artela/app/params"
-
-	"github.com/cosmos/cosmos-sdk/codec"
+	artelatypes "github.com/artela-network/artela/ethereum/types"
 )
 
 var (

--- a/ethereum/eip712/encoding_legacy.go
+++ b/ethereum/eip712/encoding_legacy.go
@@ -5,14 +5,12 @@ import (
 	"errors"
 	"fmt"
 
-	artela "github.com/artela-network/artela/ethereum/types"
-
-	"github.com/cosmos/cosmos-sdk/x/auth/migrations/legacytx"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	txTypes "github.com/cosmos/cosmos-sdk/types/tx"
-
+	"github.com/cosmos/cosmos-sdk/x/auth/migrations/legacytx"
 	"github.com/ethereum/go-ethereum/signer/core/apitypes"
+
+	artela "github.com/artela-network/artela/ethereum/types"
 )
 
 type aminoMessage struct {

--- a/ethereum/eip712/message.go
+++ b/ethereum/eip712/message.go
@@ -3,11 +3,11 @@ package eip712
 import (
 	"fmt"
 
-	errorsmod "cosmossdk.io/errors"
-	errortypes "github.com/cosmos/cosmos-sdk/types/errors"
-
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
+
+	errorsmod "cosmossdk.io/errors"
+	errortypes "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
 type eip712MessagePayload struct {

--- a/ethereum/eip712/preprocess.go
+++ b/ethereum/eip712/preprocess.go
@@ -3,13 +3,13 @@ package eip712
 import (
 	"fmt"
 
-	types2 "github.com/artela-network/artela/ethereum/types"
-
 	"github.com/cosmos/cosmos-sdk/client"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	cosmoskr "github.com/cosmos/cosmos-sdk/crypto/keyring"
 	"github.com/cosmos/cosmos-sdk/types/tx/signing"
 	authtx "github.com/cosmos/cosmos-sdk/x/auth/tx"
+
+	types2 "github.com/artela-network/artela/ethereum/types"
 )
 
 // PreprocessLedgerTx reformats Ledger-signed Cosmos transactions to match the fork expected by Artela

--- a/ethereum/eip712/types.go
+++ b/ethereum/eip712/types.go
@@ -6,14 +6,13 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/tidwall/gjson"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 
 	errorsmod "cosmossdk.io/errors"
 	errortypes "github.com/cosmos/cosmos-sdk/types/errors"
-
 	"github.com/ethereum/go-ethereum/signer/core/apitypes"
-	"github.com/tidwall/gjson"
 )
 
 const (

--- a/ethereum/rpc/api/debug.go
+++ b/ethereum/rpc/api/debug.go
@@ -16,18 +16,17 @@ import (
 	"sync"
 	"time"
 
-	tmrpctypes "github.com/cometbft/cometbft/rpc/core/types"
-	"github.com/davecgh/go-spew/spew"
-	ethtypes "github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/rpc"
-
 	stderrors "github.com/pkg/errors"
 
 	"github.com/cometbft/cometbft/libs/log"
+	tmrpctypes "github.com/cometbft/cometbft/rpc/core/types"
 	"github.com/cosmos/cosmos-sdk/server"
+	"github.com/davecgh/go-spew/spew"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/ethereum/go-ethereum/rpc"
 
 	evmtxs "github.com/artela-network/artela/x/evm/txs"
 	evmsupport "github.com/artela-network/artela/x/evm/txs/support"

--- a/ethereum/rpc/apis.go
+++ b/ethereum/rpc/apis.go
@@ -1,11 +1,10 @@
 package rpc
 
 import (
-	"github.com/ethereum/go-ethereum/log"
-	"github.com/ethereum/go-ethereum/rpc"
-
 	rpcclient "github.com/cometbft/cometbft/rpc/jsonrpc/client"
 	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rpc"
 
 	"github.com/artela-network/artela/ethereum/rpc/api"
 	"github.com/artela-network/artela/ethereum/rpc/ethapi"

--- a/ethereum/rpc/blocks.go
+++ b/ethereum/rpc/blocks.go
@@ -11,7 +11,6 @@ import (
 	"sort"
 	"strconv"
 
-	"github.com/artela-network/artela-evm/vm"
 	tmrpctypes "github.com/cometbft/cometbft/rpc/core/types"
 	sdktypes "github.com/cosmos/cosmos-sdk/types"
 	grpctypes "github.com/cosmos/cosmos-sdk/types/grpc"
@@ -29,6 +28,7 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
+	"github.com/artela-network/artela-evm/vm"
 	"github.com/artela-network/artela/ethereum/rpc/ethapi"
 	rpctypes "github.com/artela-network/artela/ethereum/rpc/types"
 	"github.com/artela-network/artela/ethereum/rpc/utils"

--- a/ethereum/rpc/config.go
+++ b/ethereum/rpc/config.go
@@ -8,9 +8,10 @@ import (
 
 	"github.com/BurntSushi/toml"
 
-	"github.com/artela-network/artela/ethereum/server/config"
 	"github.com/ethereum/go-ethereum/eth/ethconfig"
 	"github.com/ethereum/go-ethereum/eth/gasprice"
+
+	"github.com/artela-network/artela/ethereum/server/config"
 )
 
 const (

--- a/ethereum/rpc/ethapi/api.go
+++ b/ethereum/rpc/ethapi/api.go
@@ -7,9 +7,9 @@ import (
 	"math/big"
 	"time"
 
-	"github.com/artela-network/artela-evm/vm"
-	sdktypes "github.com/cosmos/cosmos-sdk/types"
 	"github.com/davecgh/go-spew/spew"
+
+	sdktypes "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -25,10 +25,10 @@ import (
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/rpc"
 
-	"github.com/artela-network/artela/x/evm/txs"
-
+	"github.com/artela-network/artela-evm/vm"
 	rpctypes "github.com/artela-network/artela/ethereum/rpc/types"
 	ethtypes "github.com/artela-network/artela/ethereum/types"
+	"github.com/artela-network/artela/x/evm/txs"
 )
 
 // EthereumAPI provides an API to access Ethereum related information.

--- a/ethereum/rpc/ethapi/backend.go
+++ b/ethereum/rpc/ethapi/backend.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"math/big"
 
-	"github.com/artela-network/artela-evm/vm"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -15,6 +14,7 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
 
+	"github.com/artela-network/artela-evm/vm"
 	rpctypes "github.com/artela-network/artela/ethereum/rpc/types"
 	"github.com/artela-network/artela/x/evm/txs"
 )

--- a/ethereum/rpc/ethapi/transaction_args.go
+++ b/ethereum/rpc/ethapi/transaction_args.go
@@ -7,8 +7,6 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/artela-network/artela/x/evm/txs"
-
 	sdkmath "cosmossdk.io/math"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -17,6 +15,8 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rpc"
+
+	"github.com/artela-network/artela/x/evm/txs"
 )
 
 // TransactionArgs represents the arguments to construct a new transaction

--- a/ethereum/rpc/filters/api.go
+++ b/ethereum/rpc/filters/api.go
@@ -10,7 +10,6 @@ import (
 	rpcclient "github.com/cometbft/cometbft/rpc/jsonrpc/client"
 	tmtypes "github.com/cometbft/cometbft/types"
 	"github.com/cosmos/cosmos-sdk/client"
-
 	"github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/eth/filters"

--- a/ethereum/rpc/filters/filter_system.go
+++ b/ethereum/rpc/filters/filter_system.go
@@ -13,14 +13,12 @@ import (
 	coretypes "github.com/cometbft/cometbft/rpc/core/types"
 	rpcclient "github.com/cometbft/cometbft/rpc/jsonrpc/client"
 	tmtypes "github.com/cometbft/cometbft/types"
-
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/eth/filters"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rpc"
-
-	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/artela-network/artela/ethereum/rpc/pubsub"
 	evmtypes "github.com/artela-network/artela/x/evm/types"

--- a/ethereum/rpc/filters/filters.go
+++ b/ethereum/rpc/filters/filters.go
@@ -9,7 +9,6 @@ import (
 	"github.com/pkg/errors"
 
 	tmrpctypes "github.com/cometbft/cometbft/rpc/core/types"
-
 	"github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"

--- a/ethereum/rpc/pubsub/pubsub_test.go
+++ b/ethereum/rpc/pubsub/pubsub_test.go
@@ -7,8 +7,9 @@ import (
 	"testing"
 	"time"
 
-	coretypes "github.com/cometbft/cometbft/rpc/core/types"
 	"github.com/stretchr/testify/require"
+
+	coretypes "github.com/cometbft/cometbft/rpc/core/types"
 )
 
 func TestAddTopic(t *testing.T) {

--- a/ethereum/rpc/service.go
+++ b/ethereum/rpc/service.go
@@ -4,7 +4,6 @@ import (
 	rpcclient "github.com/cometbft/cometbft/rpc/jsonrpc/client"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/server"
-
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rpc"
 

--- a/ethereum/rpc/tracing.go
+++ b/ethereum/rpc/tracing.go
@@ -5,13 +5,13 @@ import (
 	"fmt"
 	"math"
 
+	"github.com/pkg/errors"
+
 	tmrpcclient "github.com/cometbft/cometbft/rpc/client"
 	tmrpctypes "github.com/cometbft/cometbft/rpc/core/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/rpc"
-
-	"github.com/pkg/errors"
 
 	rpctypes "github.com/artela-network/artela/ethereum/rpc/types"
 	evmtxs "github.com/artela-network/artela/x/evm/txs"

--- a/ethereum/rpc/tx.go
+++ b/ethereum/rpc/tx.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 
 	errorsmod "cosmossdk.io/errors"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	sdktypes "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/consensus"
@@ -16,14 +18,10 @@ import (
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/rpc"
 
-	"github.com/artela-network/artela/ethereum/types"
-
-	"github.com/cosmos/cosmos-sdk/client/flags"
-	sdktypes "github.com/cosmos/cosmos-sdk/types"
-
 	"github.com/artela-network/artela/ethereum/rpc/ethapi"
 	rpctypes "github.com/artela-network/artela/ethereum/rpc/types"
 	"github.com/artela-network/artela/ethereum/rpc/utils"
+	"github.com/artela-network/artela/ethereum/types"
 	"github.com/artela-network/artela/x/evm/txs"
 	evmtypes "github.com/artela-network/artela/x/evm/types"
 )

--- a/ethereum/rpc/types/block.go
+++ b/ethereum/rpc/types/block.go
@@ -9,16 +9,15 @@ import (
 	"math/big"
 	"strings"
 
-	"github.com/artela-network/artela/ethereum/types"
-
 	"github.com/spf13/cast"
 	"google.golang.org/grpc/metadata"
 
+	grpctypes "github.com/cosmos/cosmos-sdk/types/grpc"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 
-	grpctypes "github.com/cosmos/cosmos-sdk/types/grpc"
+	"github.com/artela-network/artela/ethereum/types"
 )
 
 type Block struct {

--- a/ethereum/rpc/types/events.go
+++ b/ethereum/rpc/types/events.go
@@ -4,14 +4,13 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/artela-network/artela/ethereum/types"
-	"github.com/artela-network/artela/x/evm/txs"
-
 	abci "github.com/cometbft/cometbft/abci/types"
 	tmrpctypes "github.com/cometbft/cometbft/rpc/core/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/common"
 
+	"github.com/artela-network/artela/ethereum/types"
+	"github.com/artela-network/artela/x/evm/txs"
 	evmtypes "github.com/artela-network/artela/x/evm/types"
 )
 

--- a/ethereum/rpc/types/query_client.go
+++ b/ethereum/rpc/types/query_client.go
@@ -3,15 +3,12 @@ package types
 import (
 	"fmt"
 
+	abci "github.com/cometbft/cometbft/abci/types"
+	"github.com/cometbft/cometbft/proto/tendermint/crypto"
+	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/types/tx"
 
 	evmtypes "github.com/artela-network/artela/x/evm/txs"
-
-	abci "github.com/cometbft/cometbft/abci/types"
-	"github.com/cometbft/cometbft/proto/tendermint/crypto"
-
-	"github.com/cosmos/cosmos-sdk/client"
-
 	feetypes "github.com/artela-network/artela/x/fee/types"
 )
 

--- a/ethereum/rpc/types/utils.go
+++ b/ethereum/rpc/types/utils.go
@@ -7,22 +7,19 @@ import (
 	"math/big"
 	"strings"
 
-	evmtypes "github.com/artela-network/artela/x/evm/txs"
-
+	errorsmod "cosmossdk.io/errors"
 	abci "github.com/cometbft/cometbft/abci/types"
 	tmtypes "github.com/cometbft/cometbft/types"
-
-	errorsmod "cosmossdk.io/errors"
 	"github.com/cosmos/cosmos-sdk/client"
 	errortypes "github.com/cosmos/cosmos-sdk/types/errors"
-
-	feetypes "github.com/artela-network/artela/x/fee/types"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/common/math"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
+
+	evmtypes "github.com/artela-network/artela/x/evm/txs"
+	feetypes "github.com/artela-network/artela/x/fee/types"
 )
 
 // ExceedBlockGasLimitError defines the error message when txs execution exceeds the block gas limit.

--- a/ethereum/rpc/websockets.go
+++ b/ethereum/rpc/websockets.go
@@ -13,20 +13,19 @@ import (
 	"strconv"
 	"sync"
 
-	"github.com/cosmos/cosmos-sdk/client"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/gorilla/mux"
 	"github.com/gorilla/websocket"
 	"github.com/pkg/errors"
 
-	"github.com/ethereum/go-ethereum/common"
-	ethtypes "github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/eth/filters"
-	"github.com/ethereum/go-ethereum/rpc"
-
 	rpcclient "github.com/cometbft/cometbft/rpc/jsonrpc/client"
 	tmtypes "github.com/cometbft/cometbft/types"
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/eth/filters"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rpc"
 
 	rpcfilter "github.com/artela-network/artela/ethereum/rpc/filters"
 	"github.com/artela-network/artela/ethereum/rpc/pubsub"

--- a/ethereum/server/config/config.go
+++ b/ethereum/server/config/config.go
@@ -8,9 +8,8 @@ import (
 
 	"github.com/spf13/viper"
 
-	"github.com/cometbft/cometbft/libs/strings"
-
 	errorsmod "cosmossdk.io/errors"
+	"github.com/cometbft/cometbft/libs/strings"
 	clientflags "github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/server/config"
 	pruningtypes "github.com/cosmos/cosmos-sdk/store/pruning/types"

--- a/ethereum/server/flags/flags.go
+++ b/ethereum/server/flags/flags.go
@@ -1,10 +1,11 @@
 package flags
 
 import (
-	"github.com/cosmos/cosmos-sdk/client/flags"
-	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 )
 
 // Tendermint/cosmos-sdk full-node start flags

--- a/ethereum/server/start.go
+++ b/ethereum/server/start.go
@@ -11,10 +11,12 @@ import (
 	"runtime/pprof"
 	"time"
 
-	"github.com/artela-network/artela/ethereum/rpc"
-	"github.com/artela-network/artela/ethereum/server/config"
-	artelaflag "github.com/artela-network/artela/ethereum/server/flags"
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 
+	"cosmossdk.io/tools/rosetta"
+	crgserver "cosmossdk.io/tools/rosetta/lib/server"
 	"github.com/cometbft/cometbft/abci/server"
 	tcmd "github.com/cometbft/cometbft/cmd/cometbft/commands"
 	"github.com/cometbft/cometbft/node"
@@ -22,12 +24,6 @@ import (
 	pvm "github.com/cometbft/cometbft/privval"
 	"github.com/cometbft/cometbft/proxy"
 	"github.com/cometbft/cometbft/rpc/client/local"
-	"github.com/spf13/cobra"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
-
-	"cosmossdk.io/tools/rosetta"
-	crgserver "cosmossdk.io/tools/rosetta/lib/server"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -41,6 +37,9 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/mempool"
 
+	"github.com/artela-network/artela/ethereum/rpc"
+	"github.com/artela-network/artela/ethereum/server/config"
+	artelaflag "github.com/artela-network/artela/ethereum/server/flags"
 	aspecttypes "github.com/artela-network/aspect-core/types"
 )
 

--- a/ethereum/server/util.go
+++ b/ethereum/server/util.go
@@ -11,8 +11,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	ethlog "github.com/ethereum/go-ethereum/log"
-
 	dbm "github.com/cometbft/cometbft-db"
 	tmcmd "github.com/cometbft/cometbft/cmd/cometbft/commands"
 	rpcclient "github.com/cometbft/cometbft/rpc/jsonrpc/client"
@@ -20,6 +18,7 @@ import (
 	sdkserver "github.com/cosmos/cosmos-sdk/server"
 	"github.com/cosmos/cosmos-sdk/server/types"
 	"github.com/cosmos/cosmos-sdk/version"
+	ethlog "github.com/ethereum/go-ethereum/log"
 
 	ethrpc "github.com/artela-network/artela/ethereum/rpc"
 	"github.com/artela-network/artela/ethereum/server/config"

--- a/ethereum/types/account.go
+++ b/ethereum/types/account.go
@@ -5,7 +5,6 @@ import (
 
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 )

--- a/ethereum/types/coin.go
+++ b/ethereum/types/coin.go
@@ -4,7 +4,6 @@ import (
 	"math/big"
 
 	sdkmath "cosmossdk.io/math"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 

--- a/ethereum/utils/utils.go
+++ b/ethereum/utils/utils.go
@@ -5,19 +5,18 @@ import (
 	"math/big"
 	"strings"
 
-	"github.com/artela-network/aspect-core/djpm"
-	"github.com/ethereum/go-ethereum/common"
-	ethereum "github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/crypto"
-
-	"github.com/artela-network/artela/ethereum/crypto/ethsecp256k1"
-
 	errorsmod "cosmossdk.io/errors"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	"github.com/cosmos/cosmos-sdk/crypto/types/multisig"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	errortypes "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/ethereum/go-ethereum/common"
+	ethereum "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+
+	"github.com/artela-network/artela/ethereum/crypto/ethsecp256k1"
+	"github.com/artela-network/aspect-core/djpm"
 )
 
 const (

--- a/testutil/network/network.go
+++ b/testutil/network/network.go
@@ -15,10 +15,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/artela-network/artela/ethereum/rpc"
-	"github.com/artela-network/artela/ethereum/server/config"
-	"github.com/artela-network/artela/ethereum/types"
-	evmtypes "github.com/artela-network/artela/x/evm/txs"
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc"
 
 	"cosmossdk.io/math"
 	dbm "github.com/cometbft/cometbft-db"
@@ -28,11 +26,6 @@ import (
 	tmrand "github.com/cometbft/cometbft/libs/rand"
 	"github.com/cometbft/cometbft/node"
 	tmclient "github.com/cometbft/cometbft/rpc/client"
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/ethclient"
-	"github.com/spf13/cobra"
-	"google.golang.org/grpc"
-
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/tx"
@@ -45,10 +38,6 @@ import (
 	srvconfig "github.com/cosmos/cosmos-sdk/server/config"
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
 	pruningtypes "github.com/cosmos/cosmos-sdk/store/pruning/types"
-
-	"github.com/artela-network/artela/app"
-	"github.com/artela-network/artela/app/params"
-
 	"github.com/cosmos/cosmos-sdk/testutil"
 	simtestutil "github.com/cosmos/cosmos-sdk/testutil/sims"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -56,9 +45,17 @@ import (
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/cosmos/cosmos-sdk/x/genutil"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
 
+	"github.com/artela-network/artela/app"
+	"github.com/artela-network/artela/app/params"
 	"github.com/artela-network/artela/ethereum/crypto/hd"
 	artelakeyring "github.com/artela-network/artela/ethereum/crypto/keyring"
+	"github.com/artela-network/artela/ethereum/rpc"
+	"github.com/artela-network/artela/ethereum/server/config"
+	"github.com/artela-network/artela/ethereum/types"
+	evmtypes "github.com/artela-network/artela/x/evm/txs"
 )
 
 // package-wide network lock to only allow one test network at a time

--- a/testutil/network/network_test.go
+++ b/testutil/network/network_test.go
@@ -8,14 +8,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/artela-network/artela/ethereum/server/config"
-
 	"github.com/stretchr/testify/suite"
 
 	"github.com/ethereum/go-ethereum/ethclient"
 
+	"github.com/artela-network/artela/ethereum/server/config"
 	"github.com/artela-network/artela/testutil/network"
-
 	artelanetwork "github.com/artela-network/artela/testutil/network"
 )
 

--- a/testutil/network/util.go
+++ b/testutil/network/util.go
@@ -6,9 +6,6 @@ import (
 	"strings"
 	"time"
 
-	rpc2 "github.com/artela-network/artela/ethereum/rpc"
-	"github.com/artela-network/artela/x/evm/txs/support"
-
 	tmos "github.com/cometbft/cometbft/libs/os"
 	"github.com/cometbft/cometbft/node"
 	"github.com/cometbft/cometbft/p2p"
@@ -17,8 +14,6 @@ import (
 	"github.com/cometbft/cometbft/rpc/client/local"
 	"github.com/cometbft/cometbft/types"
 	tmtime "github.com/cometbft/cometbft/types/time"
-	"github.com/ethereum/go-ethereum/log"
-
 	"github.com/cosmos/cosmos-sdk/server/api"
 	servergrpc "github.com/cosmos/cosmos-sdk/server/grpc"
 	srvtypes "github.com/cosmos/cosmos-sdk/server/types"
@@ -30,7 +25,10 @@ import (
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	govv1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"github.com/ethereum/go-ethereum/log"
 
+	rpc2 "github.com/artela-network/artela/ethereum/rpc"
+	"github.com/artela-network/artela/x/evm/txs/support"
 	evmtypes "github.com/artela-network/artela/x/evm/types"
 )
 

--- a/testutil/tx/cosmos.go
+++ b/testutil/tx/cosmos.go
@@ -3,8 +3,6 @@ package tx
 import (
 	"math"
 
-	"github.com/artela-network/artela/ethereum/utils"
-
 	sdkmath "cosmossdk.io/math"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/tx"
@@ -14,6 +12,7 @@ import (
 	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
 
 	"github.com/artela-network/artela/app"
+	"github.com/artela-network/artela/ethereum/utils"
 )
 
 var (

--- a/testutil/tx/eip712.go
+++ b/testutil/tx/eip712.go
@@ -3,9 +3,6 @@ package tx
 import (
 	"errors"
 
-	cryptocodec "github.com/artela-network/artela/ethereum/crypto/codec"
-	types2 "github.com/artela-network/artela/ethereum/types"
-
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
@@ -19,7 +16,9 @@ import (
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 
 	"github.com/artela-network/artela/app"
+	cryptocodec "github.com/artela-network/artela/ethereum/crypto/codec"
 	"github.com/artela-network/artela/ethereum/eip712"
+	types2 "github.com/artela-network/artela/ethereum/types"
 )
 
 type EIP712TxArgs struct {

--- a/testutil/tx/eth.go
+++ b/testutil/tx/eth.go
@@ -4,10 +4,6 @@ import (
 	"encoding/json"
 	"math/big"
 
-	"github.com/artela-network/artela/ethereum/server/config"
-	"github.com/artela-network/artela/ethereum/utils"
-	"github.com/artela-network/artela/x/evm/txs"
-
 	errorsmod "cosmossdk.io/errors"
 	sdkmath "cosmossdk.io/math"
 	"github.com/cosmos/cosmos-sdk/client"
@@ -21,6 +17,9 @@ import (
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 
 	"github.com/artela-network/artela/app"
+	"github.com/artela-network/artela/ethereum/server/config"
+	"github.com/artela-network/artela/ethereum/utils"
+	"github.com/artela-network/artela/x/evm/txs"
 )
 
 // PrepareEthTx creates an ethereum txs and signs it with the provided messages and private key.

--- a/testutil/tx/signer.go
+++ b/testutil/tx/signer.go
@@ -3,14 +3,13 @@ package tx
 import (
 	"fmt"
 
-	ethsecp256k12 "github.com/artela-network/artela/ethereum/crypto/ethsecp256k1"
-
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/crypto"
-
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+
+	ethsecp256k12 "github.com/artela-network/artela/ethereum/crypto/ethsecp256k1"
 )
 
 // NewAddrKey generates an Ethereum address and its corresponding private key.

--- a/x/evm/artela/api/aspect_property_api.go
+++ b/x/evm/artela/api/aspect_property_api.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"errors"
+
 	"github.com/artela-network/artela/x/evm/artela/contract"
 	"github.com/artela-network/artela/x/evm/artela/types"
 	asptypes "github.com/artela-network/aspect-core/types"

--- a/x/evm/artela/api/aspect_runtime_ctx_api.go
+++ b/x/evm/artela/api/aspect_runtime_ctx_api.go
@@ -5,14 +5,14 @@ import (
 	"errors"
 	"fmt"
 
-	aspctx "github.com/artela-network/aspect-core/context"
-	"github.com/cosmos/gogoproto/proto"
 	"github.com/emirpasic/gods/sets/hashset"
 
-	asptypes "github.com/artela-network/aspect-core/types"
+	"github.com/cosmos/gogoproto/proto"
 
 	"github.com/artela-network/artela/x/evm/artela/api/datactx"
 	"github.com/artela-network/artela/x/evm/artela/types"
+	aspctx "github.com/artela-network/aspect-core/context"
+	asptypes "github.com/artela-network/aspect-core/types"
 )
 
 var (

--- a/x/evm/artela/api/aspect_state_api.go
+++ b/x/evm/artela/api/aspect_state_api.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"errors"
 
-	asptypes "github.com/artela-network/aspect-core/types"
 	"github.com/emirpasic/gods/sets/hashset"
 
 	"github.com/artela-network/artela/x/evm/artela/types"
+	asptypes "github.com/artela-network/aspect-core/types"
 )
 
 var (

--- a/x/evm/artela/api/aspect_transient_storage_api.go
+++ b/x/evm/artela/api/aspect_transient_storage_api.go
@@ -3,10 +3,13 @@ package api
 import (
 	"context"
 	"errors"
+
+	"github.com/emirpasic/gods/sets/hashset"
+
+	"github.com/ethereum/go-ethereum/common"
+
 	"github.com/artela-network/artela/x/evm/artela/types"
 	asptypes "github.com/artela-network/aspect-core/types"
-	"github.com/emirpasic/gods/sets/hashset"
-	"github.com/ethereum/go-ethereum/common"
 )
 
 var (

--- a/x/evm/artela/api/datactx/aspect.go
+++ b/x/evm/artela/api/datactx/aspect.go
@@ -3,9 +3,10 @@ package datactx
 import (
 	"errors"
 
+	"google.golang.org/protobuf/proto"
+
 	aspctx "github.com/artela-network/aspect-core/context"
 	artelatypes "github.com/artela-network/aspect-core/types"
-	"google.golang.org/protobuf/proto"
 )
 
 type AspectContextFieldLoader func(ctx *artelatypes.RunnerContext) proto.Message

--- a/x/evm/artela/api/datactx/block.go
+++ b/x/evm/artela/api/datactx/block.go
@@ -3,11 +3,11 @@ package datactx
 import (
 	"errors"
 
-	"github.com/artela-network/aspect-core/context"
-	artelatypes "github.com/artela-network/aspect-core/types"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/artela-network/artela/x/evm/artela/types"
+	"github.com/artela-network/aspect-core/context"
+	artelatypes "github.com/artela-network/aspect-core/types"
 )
 
 type BlockContextFieldLoader func(blockCtx *types.EthBlockContext) proto.Message

--- a/x/evm/artela/api/datactx/env.go
+++ b/x/evm/artela/api/datactx/env.go
@@ -3,12 +3,12 @@ package datactx
 import (
 	"strings"
 
-	"github.com/artela-network/aspect-core/context"
-	artelatypes "github.com/artela-network/aspect-core/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/artela-network/artela/x/evm/artela/types"
+	"github.com/artela-network/aspect-core/context"
+	artelatypes "github.com/artela-network/aspect-core/types"
 )
 
 type EnvContextFieldLoader func(sdkCtx sdk.Context, ethTxCtx *types.EthTxContext) proto.Message

--- a/x/evm/artela/api/datactx/msg.go
+++ b/x/evm/artela/api/datactx/msg.go
@@ -3,13 +3,13 @@ package datactx
 import (
 	"errors"
 
-	aspctx "github.com/artela-network/aspect-core/context"
-	artelatypes "github.com/artela-network/aspect-core/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/core"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/artela-network/artela/x/evm/artela/types"
+	aspctx "github.com/artela-network/aspect-core/context"
+	artelatypes "github.com/artela-network/aspect-core/types"
 )
 
 type MessageContextFieldLoader func(ethTxCtx *types.EthTxContext, message *core.Message) proto.Message

--- a/x/evm/artela/api/datactx/receipt.go
+++ b/x/evm/artela/api/datactx/receipt.go
@@ -3,13 +3,13 @@ package datactx
 import (
 	"errors"
 
-	aspctx "github.com/artela-network/aspect-core/context"
-	artelatypes "github.com/artela-network/aspect-core/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	ethereum "github.com/ethereum/go-ethereum/core/types"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/artela-network/artela/x/evm/artela/types"
+	aspctx "github.com/artela-network/aspect-core/context"
+	artelatypes "github.com/artela-network/aspect-core/types"
 )
 
 type ReceiptContextFieldLoader func(ethTxCtx *types.EthTxContext, receipt *ethereum.Receipt) proto.Message

--- a/x/evm/artela/api/datactx/tx.go
+++ b/x/evm/artela/api/datactx/tx.go
@@ -5,14 +5,14 @@ import (
 	"errors"
 	"math/big"
 
-	aspctx "github.com/artela-network/aspect-core/context"
-	artelatypes "github.com/artela-network/aspect-core/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	ethereum "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rlp"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/artela-network/artela/x/evm/artela/types"
+	aspctx "github.com/artela-network/aspect-core/context"
+	artelatypes "github.com/artela-network/aspect-core/types"
 )
 
 type TxContextFieldLoader func(ethTxCtx *types.EthTxContext, tx *ethereum.Transaction) proto.Message

--- a/x/evm/artela/api/datactx/types.go
+++ b/x/evm/artela/api/datactx/types.go
@@ -1,8 +1,9 @@
 package datactx
 
 import (
-	artelatypes "github.com/artela-network/aspect-core/types"
 	"math/big"
+
+	artelatypes "github.com/artela-network/aspect-core/types"
 )
 
 type ContextLoader func(ctx *artelatypes.RunnerContext) ([]byte, error)

--- a/x/evm/artela/api/evm_api.go
+++ b/x/evm/artela/api/evm_api.go
@@ -3,17 +3,18 @@ package api
 import (
 	"context"
 	"errors"
+
 	"github.com/emirpasic/gods/sets/hashset"
 
-	"github.com/artela-network/artela-evm/vm"
-	asptypes "github.com/artela-network/aspect-core/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/log"
 
+	"github.com/artela-network/artela-evm/vm"
 	artelatypes "github.com/artela-network/artela/x/evm/artela/types"
 	"github.com/artela-network/artela/x/evm/states"
 	types "github.com/artela-network/artela/x/evm/txs"
+	asptypes "github.com/artela-network/aspect-core/types"
 )
 
 var (

--- a/x/evm/artela/api/globals.go
+++ b/x/evm/artela/api/globals.go
@@ -1,12 +1,14 @@
 package api
 
 import (
-	"github.com/artela-network/artela-evm/vm"
-	"github.com/artela-network/artela/x/evm/states"
+	"math/big"
+
 	cosmos "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
-	"math/big"
+
+	"github.com/artela-network/artela-evm/vm"
+	"github.com/artela-network/artela/x/evm/states"
 )
 
 // globals, we need to manage the lifecycle carefully for the following hooks / variables

--- a/x/evm/artela/api/statedb_api.go
+++ b/x/evm/artela/api/statedb_api.go
@@ -2,9 +2,11 @@ package api
 
 import (
 	"context"
+
+	"github.com/pkg/errors"
+
 	"github.com/artela-network/artela/x/evm/artela/types"
 	artelatypes "github.com/artela-network/aspect-core/types"
-	"github.com/pkg/errors"
 )
 
 func GetStateDBHostInstance(ctx context.Context) (artelatypes.StateDBHostAPI, error) {

--- a/x/evm/artela/api/trace_api.go
+++ b/x/evm/artela/api/trace_api.go
@@ -3,15 +3,16 @@ package api
 import (
 	"context"
 	"errors"
-	"github.com/emirpasic/gods/sets/hashset"
 	"sort"
 
-	"github.com/artela-network/artela-evm/vm"
-	artelatypes "github.com/artela-network/aspect-core/types"
-	"github.com/ethereum/go-ethereum/common"
+	"github.com/emirpasic/gods/sets/hashset"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/artela-network/artela-evm/vm"
 	"github.com/artela-network/artela/x/evm/artela/types"
+	artelatypes "github.com/artela-network/aspect-core/types"
 )
 
 var (

--- a/x/evm/artela/contract/contract.go
+++ b/x/evm/artela/contract/contract.go
@@ -1,19 +1,19 @@
 package contract
 
 import (
-	"github.com/artela-network/artela/common"
 	"strings"
 
-	"github.com/artela-network/artela/x/evm/states"
-
-	errorsmod "cosmossdk.io/errors"
-	"github.com/artela-network/artela-evm/vm"
-	"github.com/artela-network/artela/x/evm/artela/types"
-	evmtypes "github.com/artela-network/artela/x/evm/types"
 	"github.com/cometbft/cometbft/libs/log"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/core"
+
+	errorsmod "cosmossdk.io/errors"
+	"github.com/artela-network/artela-evm/vm"
+	"github.com/artela-network/artela/common"
+	"github.com/artela-network/artela/x/evm/artela/types"
+	"github.com/artela-network/artela/x/evm/states"
+	evmtypes "github.com/artela-network/artela/x/evm/types"
 )
 
 type AspectNativeContract struct {

--- a/x/evm/artela/contract/handlers.go
+++ b/x/evm/artela/contract/handlers.go
@@ -4,6 +4,15 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"math/big"
+	"time"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/holiman/uint256"
+
 	"github.com/artela-network/artela-evm/vm"
 	common2 "github.com/artela-network/artela/common"
 	"github.com/artela-network/artela/x/evm/artela/types"
@@ -13,13 +22,6 @@ import (
 	artelasdkType "github.com/artela-network/aspect-core/types"
 	runtime "github.com/artela-network/aspect-runtime"
 	runtimeTypes "github.com/artela-network/aspect-runtime/types"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/ethereum/go-ethereum/accounts/abi"
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/holiman/uint256"
-	"math/big"
-	"time"
 )
 
 var (

--- a/x/evm/artela/contract/service.go
+++ b/x/evm/artela/contract/service.go
@@ -1,7 +1,8 @@
 package contract
 
 import (
-	artela "github.com/artela-network/aspect-core/types"
+	"math/big"
+
 	"github.com/cometbft/cometbft/libs/log"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -9,9 +10,9 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/holiman/uint256"
 	"github.com/pkg/errors"
-	"math/big"
 
 	evmtypes "github.com/artela-network/artela/x/evm/artela/types"
+	artela "github.com/artela-network/aspect-core/types"
 )
 
 type AspectService struct {

--- a/x/evm/artela/contract/store.go
+++ b/x/evm/artela/contract/store.go
@@ -4,25 +4,25 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	types2 "github.com/artela-network/aspect-runtime/types"
 	"math"
 	"math/big"
 	"sort"
 	"strings"
 
-	artelasdkType "github.com/artela-network/aspect-core/types"
+	"github.com/emirpasic/gods/sets/treeset"
+	"github.com/holiman/uint256"
+	"golang.org/x/exp/slices"
 
 	"github.com/cometbft/cometbft/libs/log"
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/emirpasic/gods/sets/treeset"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/holiman/uint256"
-	"golang.org/x/exp/slices"
 
 	"github.com/artela-network/artela/x/evm/artela/types"
 	evmtypes "github.com/artela-network/artela/x/evm/types"
+	artelasdkType "github.com/artela-network/aspect-core/types"
+	types2 "github.com/artela-network/aspect-runtime/types"
 )
 
 const (

--- a/x/evm/artela/contract/utils.go
+++ b/x/evm/artela/contract/utils.go
@@ -4,9 +4,10 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
+
 	"github.com/andybalholm/brotli"
 	"github.com/ethereum/go-ethereum/crypto"
-	"io"
 )
 
 // ParseByteCode byte code format rules:

--- a/x/evm/artela/provider/artela.go
+++ b/x/evm/artela/provider/artela.go
@@ -3,12 +3,14 @@ package provider
 import (
 	"context"
 	"errors"
-	"github.com/artela-network/artela/x/evm/artela/contract"
-	"github.com/artela-network/artela/x/evm/artela/types"
-	asptypes "github.com/artela-network/aspect-core/types"
+
 	"github.com/cometbft/cometbft/libs/log"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/artela-network/artela/x/evm/artela/contract"
+	"github.com/artela-network/artela/x/evm/artela/types"
+	asptypes "github.com/artela-network/aspect-core/types"
 )
 
 var _ asptypes.AspectProvider = (*ArtelaProvider)(nil)

--- a/x/evm/artela/provider/jit_call.go
+++ b/x/evm/artela/provider/jit_call.go
@@ -3,10 +3,10 @@ package provider
 import (
 	"math/big"
 
-	"github.com/artela-network/aspect-core/integration"
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/artela-network/artela/x/evm/artela/types"
+	"github.com/artela-network/aspect-core/integration"
 )
 
 var _ integration.AspectProtocol = (*AspectProtocolProvider)(nil)

--- a/x/evm/artela/types/aspect_abi_test.go
+++ b/x/evm/artela/types/aspect_abi_test.go
@@ -6,11 +6,11 @@ import (
 	"reflect"
 	"testing"
 
+	pq "github.com/emirpasic/gods/queues/priorityqueue"
+	"github.com/emirpasic/gods/sets/treeset"
 	"github.com/holiman/uint256"
 	jsoniter "github.com/json-iterator/go"
 
-	pq "github.com/emirpasic/gods/queues/priorityqueue"
-	"github.com/emirpasic/gods/sets/treeset"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"

--- a/x/evm/artela/types/aspect_store_key.go
+++ b/x/evm/artela/types/aspect_store_key.go
@@ -6,10 +6,12 @@ import (
 	"math"
 	"strings"
 
-	artela "github.com/artela-network/aspect-core/types"
 	"github.com/emirpasic/gods/utils"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/holiman/uint256"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	artela "github.com/artela-network/aspect-core/types"
 )
 
 var _ binary.ByteOrder

--- a/x/evm/artela/types/context.go
+++ b/x/evm/artela/types/context.go
@@ -3,11 +3,11 @@ package types
 import (
 	"context"
 	"fmt"
-	"github.com/artela-network/artela-evm/vm"
-	statedb "github.com/artela-network/artela/x/evm/states"
-	evmtypes "github.com/artela-network/artela/x/evm/types"
-	inherent "github.com/artela-network/aspect-core/chaincoreext/jit_inherent"
-	artelatypes "github.com/artela-network/aspect-core/types"
+
+	"math/big"
+	"sync"
+	"time"
+
 	abci "github.com/cometbft/cometbft/abci/types"
 	"github.com/cometbft/cometbft/libs/log"
 	"github.com/cosmos/cosmos-sdk/client"
@@ -17,9 +17,12 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
-	"math/big"
-	"sync"
-	"time"
+
+	"github.com/artela-network/artela-evm/vm"
+	statedb "github.com/artela-network/artela/x/evm/states"
+	evmtypes "github.com/artela-network/artela/x/evm/types"
+	inherent "github.com/artela-network/aspect-core/chaincoreext/jit_inherent"
+	artelatypes "github.com/artela-network/aspect-core/types"
 )
 
 const (

--- a/x/evm/blocker.go
+++ b/x/evm/blocker.go
@@ -3,14 +3,12 @@ package evm
 import (
 	"sync"
 
-	"github.com/artela-network/artela/x/evm/artela/types"
 	abci "github.com/cometbft/cometbft/abci/types"
-
-	"github.com/artela-network/artela/x/evm/keeper"
-
 	cosmos "github.com/cosmos/cosmos-sdk/types"
-
 	ethereum "github.com/ethereum/go-ethereum/core/types"
+
+	"github.com/artela-network/artela/x/evm/artela/types"
+	"github.com/artela-network/artela/x/evm/keeper"
 )
 
 // BeginBlock sets the cosmos Context and EIP155 chain id to the Keeper.

--- a/x/evm/client/cli/query.go
+++ b/x/evm/client/cli/query.go
@@ -1,13 +1,13 @@
 package cli
 
 import (
-	rpc "github.com/artela-network/artela/ethereum/rpc/types"
-	"github.com/artela-network/artela/x/evm/txs"
 	"github.com/spf13/cobra"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 
+	rpc "github.com/artela-network/artela/ethereum/rpc/types"
+	"github.com/artela-network/artela/x/evm/txs"
 	"github.com/artela-network/artela/x/evm/types"
 )
 

--- a/x/evm/client/cli/tx.go
+++ b/x/evm/client/cli/tx.go
@@ -5,16 +5,16 @@ import (
 	"fmt"
 	"os"
 
-	rpc "github.com/artela-network/artela/ethereum/rpc/types"
-	"github.com/artela-network/artela/x/evm/txs"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/input"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
 
+	rpc "github.com/artela-network/artela/ethereum/rpc/types"
+	"github.com/artela-network/artela/x/evm/txs"
 	"github.com/artela-network/artela/x/evm/types"
 )
 

--- a/x/evm/client/cli/utils.go
+++ b/x/evm/client/cli/utils.go
@@ -6,9 +6,8 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/ethereum/go-ethereum/common"
-
 	cosmos "github.com/cosmos/cosmos-sdk/types"
+	"github.com/ethereum/go-ethereum/common"
 )
 
 func accountToHex(addr string) (string, error) {

--- a/x/evm/genesis.go
+++ b/x/evm/genesis.go
@@ -4,16 +4,15 @@ import (
 	"bytes"
 	"fmt"
 
-	artela "github.com/artela-network/artela/ethereum/types"
-	"github.com/artela-network/artela/x/evm/txs/support"
-
-	"github.com/artela-network/artela/x/evm/keeper"
 	abci "github.com/cometbft/cometbft/abci/types"
 	cosmos "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 
+	artela "github.com/artela-network/artela/ethereum/types"
+	"github.com/artela-network/artela/x/evm/keeper"
+	"github.com/artela-network/artela/x/evm/txs/support"
 	"github.com/artela-network/artela/x/evm/types"
 )
 

--- a/x/evm/keeper/aspect.go
+++ b/x/evm/keeper/aspect.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"errors"
 
-	artvmtype "github.com/artela-network/artela/x/evm/artela/types"
 	"github.com/ethereum/go-ethereum/common"
+
+	artvmtype "github.com/artela-network/artela/x/evm/artela/types"
 )
 
 func (k Keeper) GetAspectRuntimeContext() *artvmtype.AspectRuntimeContext {

--- a/x/evm/keeper/config.go
+++ b/x/evm/keeper/config.go
@@ -3,16 +3,14 @@ package keeper
 import (
 	"math/big"
 
-	"github.com/artela-network/artela-evm/vm"
-
-	"github.com/artela-network/artela/x/evm/txs/support"
-
 	errorsmod "cosmossdk.io/errors"
 	cosmos "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 
+	"github.com/artela-network/artela-evm/vm"
 	"github.com/artela-network/artela/x/evm/states"
+	"github.com/artela-network/artela/x/evm/txs/support"
 )
 
 // ----------------------------------------------------------------------------

--- a/x/evm/keeper/evm.go
+++ b/x/evm/keeper/evm.go
@@ -4,17 +4,8 @@ import (
 	"errors"
 	"math/big"
 
-	asptypes "github.com/artela-network/aspect-core/types"
-
-	"github.com/artela-network/artela/x/evm/artela/contract"
-	artelatypes "github.com/artela-network/artela/x/evm/artela/types"
-
-	"github.com/artela-network/aspect-core/djpm"
-	cometbft "github.com/cometbft/cometbft/types"
-
 	errorsmod "cosmossdk.io/errors"
-	artcore "github.com/artela-network/artela-evm/core"
-	"github.com/artela-network/artela-evm/vm"
+	cometbft "github.com/cometbft/cometbft/types"
 	cosmos "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
@@ -22,11 +13,17 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
 
+	artcore "github.com/artela-network/artela-evm/core"
+	"github.com/artela-network/artela-evm/vm"
 	artela "github.com/artela-network/artela/ethereum/types"
+	"github.com/artela-network/artela/x/evm/artela/contract"
+	artelatypes "github.com/artela-network/artela/x/evm/artela/types"
 	"github.com/artela-network/artela/x/evm/states"
 	"github.com/artela-network/artela/x/evm/txs"
 	"github.com/artela-network/artela/x/evm/txs/support"
 	"github.com/artela-network/artela/x/evm/types"
+	"github.com/artela-network/aspect-core/djpm"
+	asptypes "github.com/artela-network/aspect-core/types"
 )
 
 // NewEVM generates a go-ethereum VM from the provided Message fields and the chain parameters

--- a/x/evm/keeper/grpc_query.go
+++ b/x/evm/keeper/grpc_query.go
@@ -8,30 +8,26 @@ import (
 	"math/big"
 	"time"
 
-	"github.com/artela-network/artela/x/evm/txs"
-	"github.com/artela-network/artela/x/evm/txs/support"
-
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
 	"cosmossdk.io/math"
 	cosmos "github.com/cosmos/cosmos-sdk/types"
-
-	"github.com/artela-network/artela-evm/tracers"
-	"github.com/artela-network/artela-evm/tracers/logger"
-	"github.com/artela-network/artela-evm/vm"
-
-	artela "github.com/artela-network/artela/ethereum/types"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core"
 	ethereum "github.com/ethereum/go-ethereum/core/types"
 	ethparams "github.com/ethereum/go-ethereum/params"
 
+	"github.com/artela-network/artela-evm/tracers"
+	"github.com/artela-network/artela-evm/tracers/logger"
+	"github.com/artela-network/artela-evm/vm"
+	artela "github.com/artela-network/artela/ethereum/types"
 	"github.com/artela-network/artela/x/evm/artela/provider"
 	artelatypes "github.com/artela-network/artela/x/evm/artela/types"
 	"github.com/artela-network/artela/x/evm/states"
+	"github.com/artela-network/artela/x/evm/txs"
+	"github.com/artela-network/artela/x/evm/txs/support"
 	"github.com/artela-network/artela/x/evm/types"
 	inherent "github.com/artela-network/aspect-core/chaincoreext/jit_inherent"
 )

--- a/x/evm/keeper/keeper.go
+++ b/x/evm/keeper/keeper.go
@@ -6,22 +6,10 @@ import (
 	"math/big"
 	"sync"
 
-	"github.com/artela-network/aspect-core/djpm"
-	"github.com/cosmos/cosmos-sdk/baseapp"
-	"github.com/cosmos/cosmos-sdk/client"
-
-	"github.com/artela-network/artela/x/evm/artela/api"
-	"github.com/artela-network/artela/x/evm/artela/provider"
-
-	"github.com/artela-network/artela-evm/vm"
-
-	artela "github.com/artela-network/artela/ethereum/types"
-	"github.com/artela-network/artela/x/evm/states"
-	"github.com/artela-network/artela/x/evm/txs"
-	"github.com/artela-network/artela/x/evm/txs/support"
-
 	errorsmod "cosmossdk.io/errors"
 	"github.com/cometbft/cometbft/libs/log"
+	"github.com/cosmos/cosmos-sdk/baseapp"
+	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
@@ -32,9 +20,17 @@ import (
 	ethereum "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
 
+	"github.com/artela-network/artela-evm/vm"
 	common2 "github.com/artela-network/artela/common"
+	artela "github.com/artela-network/artela/ethereum/types"
+	"github.com/artela-network/artela/x/evm/artela/api"
+	"github.com/artela-network/artela/x/evm/artela/provider"
 	artvmtype "github.com/artela-network/artela/x/evm/artela/types"
+	"github.com/artela-network/artela/x/evm/states"
+	"github.com/artela-network/artela/x/evm/txs"
+	"github.com/artela-network/artela/x/evm/txs/support"
 	"github.com/artela-network/artela/x/evm/types"
+	"github.com/artela-network/aspect-core/djpm"
 	artelaType "github.com/artela-network/aspect-core/types"
 )
 

--- a/x/evm/keeper/meter.go
+++ b/x/evm/keeper/meter.go
@@ -1,11 +1,12 @@
 package keeper
 
 import (
-	"github.com/artela-network/aspect-core/djpm"
 	"math/big"
 
-	"github.com/artela-network/artela/x/evm/txs"
-	"github.com/artela-network/artela/x/evm/types"
+	errorsmod "cosmossdk.io/errors"
+	sdkmath "cosmossdk.io/math"
+	cosmos "github.com/cosmos/cosmos-sdk/types"
+	errortypes "github.com/cosmos/cosmos-sdk/types/errors"
 	authante "github.com/cosmos/cosmos-sdk/x/auth/ante"
 	authmodule "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/ethereum/go-ethereum/common"
@@ -13,10 +14,9 @@ import (
 	ethereum "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
 
-	errorsmod "cosmossdk.io/errors"
-	sdkmath "cosmossdk.io/math"
-	cosmos "github.com/cosmos/cosmos-sdk/types"
-	errortypes "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/artela-network/artela/x/evm/txs"
+	"github.com/artela-network/artela/x/evm/types"
+	"github.com/artela-network/aspect-core/djpm"
 )
 
 // GetEthIntrinsicGas returns the intrinsic gas cost for the transaction.

--- a/x/evm/keeper/msg_server.go
+++ b/x/evm/keeper/msg_server.go
@@ -6,18 +6,15 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/artela-network/artela/x/evm/txs"
-
-	govmodule "github.com/cosmos/cosmos-sdk/x/gov/types"
-
-	tmbytes "github.com/cometbft/cometbft/libs/bytes"
-	cometbft "github.com/cometbft/cometbft/types"
-
 	errorsmod "cosmossdk.io/errors"
 	"github.com/armon/go-metrics"
+	tmbytes "github.com/cometbft/cometbft/libs/bytes"
+	cometbft "github.com/cometbft/cometbft/types"
 	"github.com/cosmos/cosmos-sdk/telemetry"
 	cosmos "github.com/cosmos/cosmos-sdk/types"
+	govmodule "github.com/cosmos/cosmos-sdk/x/gov/types"
 
+	"github.com/artela-network/artela/x/evm/txs"
 	"github.com/artela-network/artela/x/evm/types"
 )
 

--- a/x/evm/keeper/params.go
+++ b/x/evm/keeper/params.go
@@ -2,10 +2,12 @@ package keeper
 
 import (
 	"fmt"
-	"github.com/artela-network/artela/x/evm/txs/support"
-	"github.com/artela-network/artela/x/evm/types"
+
 	cosmos "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/params"
+
+	"github.com/artela-network/artela/x/evm/txs/support"
+	"github.com/artela-network/artela/x/evm/types"
 )
 
 // GetParams returns the total set of evm parameters.

--- a/x/evm/keeper/statedb.go
+++ b/x/evm/keeper/statedb.go
@@ -4,17 +4,17 @@ import (
 	"fmt"
 	"math/big"
 
-	artela "github.com/artela-network/artela/ethereum/types"
 	"github.com/status-im/keycard-go/hexutils"
 
-	sdkmath "cosmossdk.io/math"
-
 	errorsmod "cosmossdk.io/errors"
-	"github.com/artela-network/artela/x/evm/states"
-	"github.com/artela-network/artela/x/evm/types"
+	sdkmath "cosmossdk.io/math"
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	cosmos "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/common"
+
+	artela "github.com/artela-network/artela/ethereum/types"
+	"github.com/artela-network/artela/x/evm/states"
+	"github.com/artela-network/artela/x/evm/types"
 )
 
 var _ states.Keeper = &Keeper{}

--- a/x/evm/keeper/tx_verify.go
+++ b/x/evm/keeper/tx_verify.go
@@ -4,17 +4,17 @@ import (
 	"errors"
 	"math/big"
 
-	"github.com/artela-network/artela/ethereum/utils"
-	"github.com/ethereum/go-ethereum/params"
-
 	errorsmod "cosmossdk.io/errors"
-	artelatype "github.com/artela-network/artela/x/evm/artela/types"
-	"github.com/artela-network/artela/x/evm/states"
-	"github.com/artela-network/aspect-core/djpm"
 	cosmos "github.com/cosmos/cosmos-sdk/types"
 	errortypes "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/ethereum/go-ethereum/common"
 	ethereum "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
+
+	"github.com/artela-network/artela/ethereum/utils"
+	artelatype "github.com/artela-network/artela/x/evm/artela/types"
+	"github.com/artela-network/artela/x/evm/states"
+	"github.com/artela-network/aspect-core/djpm"
 )
 
 func (k *Keeper) VerifySig(ctx cosmos.Context, tx *ethereum.Transaction) (common.Address, []byte, error) {

--- a/x/evm/module.go
+++ b/x/evm/module.go
@@ -8,11 +8,7 @@ import (
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/spf13/cobra"
 
-	"github.com/artela-network/artela/x/evm/txs"
-	"github.com/artela-network/artela/x/evm/txs/support"
-
 	abci "github.com/cometbft/cometbft/abci/types"
-
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
@@ -22,6 +18,8 @@ import (
 
 	"github.com/artela-network/artela/x/evm/client/cli"
 	"github.com/artela-network/artela/x/evm/keeper"
+	"github.com/artela-network/artela/x/evm/txs"
+	"github.com/artela-network/artela/x/evm/txs/support"
 	"github.com/artela-network/artela/x/evm/types"
 )
 

--- a/x/evm/states/config.go
+++ b/x/evm/states/config.go
@@ -3,9 +3,10 @@ package states
 import (
 	"math/big"
 
-	"github.com/artela-network/artela/x/evm/txs/support"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/params"
+
+	"github.com/artela-network/artela/x/evm/txs/support"
 )
 
 // EVMConfig encapsulates common parameters needed to create an EVM to execute a message

--- a/x/evm/states/interface.go
+++ b/x/evm/states/interface.go
@@ -1,9 +1,10 @@
 package states
 
 import (
-	"github.com/artela-network/artela-evm/vm"
 	cosmos "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/artela-network/artela-evm/vm"
 )
 
 // ExtStateDB defines an extension to the interface provided by the go-ethereum

--- a/x/evm/states/statedb.go
+++ b/x/evm/states/statedb.go
@@ -8,12 +8,13 @@ import (
 	"sort"
 
 	errorsmod "cosmossdk.io/errors"
-	"github.com/artela-network/artela-evm/vm"
 	cosmos "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/common"
 	ethereum "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
+
+	"github.com/artela-network/artela-evm/vm"
 )
 
 type revision struct {

--- a/x/evm/txs/eip2930.go
+++ b/x/evm/txs/eip2930.go
@@ -14,9 +14,10 @@ package txs
 // such as the transition to Ethereum 2.0, by allowing transactions to explicitly states their dependencies.
 
 import (
-	"github.com/artela-network/artela/x/evm/txs/support"
 	"github.com/ethereum/go-ethereum/common"
 	ethereum "github.com/ethereum/go-ethereum/core/types"
+
+	"github.com/artela-network/artela/x/evm/txs/support"
 )
 
 // AccessList is EIP-2930 access list

--- a/x/evm/txs/support/chain_config.go
+++ b/x/evm/txs/support/chain_config.go
@@ -5,15 +5,13 @@ import (
 	"math/big"
 	"strings"
 
-	"github.com/artela-network/artela/x/evm/types"
-
-	sdkmath "cosmossdk.io/math"
-
 	errorsmod "cosmossdk.io/errors"
+	sdkmath "cosmossdk.io/math"
 	cosmos "github.com/cosmos/cosmos-sdk/types"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/params"
+
+	"github.com/artela-network/artela/x/evm/types"
 )
 
 const (

--- a/x/evm/txs/support/logs.go
+++ b/x/evm/txs/support/logs.go
@@ -4,9 +4,10 @@ import (
 	"errors"
 	"fmt"
 
-	artela "github.com/artela-network/artela/ethereum/types"
 	"github.com/ethereum/go-ethereum/common"
 	ethereum "github.com/ethereum/go-ethereum/core/types"
+
+	artela "github.com/artela-network/artela/ethereum/types"
 )
 
 // ----------------------------------------------------------------------------

--- a/x/evm/txs/support/params.go
+++ b/x/evm/txs/support/params.go
@@ -4,14 +4,12 @@ import (
 	"fmt"
 	"math/big"
 
+	cosmos "github.com/cosmos/cosmos-sdk/types"
 	paramsmodule "github.com/cosmos/cosmos-sdk/x/params/types"
-
-	"github.com/artela-network/artela/ethereum/utils"
-
-	"github.com/artela-network/artela-evm/vm"
 	"github.com/ethereum/go-ethereum/params"
 
-	cosmos "github.com/cosmos/cosmos-sdk/types"
+	"github.com/artela-network/artela-evm/vm"
+	"github.com/artela-network/artela/ethereum/utils"
 )
 
 var (

--- a/x/evm/txs/support/storage.go
+++ b/x/evm/txs/support/storage.go
@@ -5,9 +5,9 @@ import (
 	"strings"
 
 	errorsmod "cosmossdk.io/errors"
+	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/artela-network/artela/x/evm/types"
-	"github.com/ethereum/go-ethereum/common"
 )
 
 // ----------------------------------------------------------------------------

--- a/x/evm/txs/tracer.go
+++ b/x/evm/txs/tracer.go
@@ -4,12 +4,12 @@ import (
 	"math/big"
 	"os"
 
-	"github.com/artela-network/artela-evm/tracers/logger"
-
-	"github.com/artela-network/artela-evm/vm"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/params"
+
+	"github.com/artela-network/artela-evm/tracers/logger"
+	"github.com/artela-network/artela-evm/vm"
 )
 
 const (

--- a/x/evm/txs/tx_access_list.go
+++ b/x/evm/txs/tx_access_list.go
@@ -3,19 +3,16 @@ package txs
 import (
 	"math/big"
 
-	"github.com/artela-network/aspect-core/djpm"
-
-	"github.com/artela-network/artela/ethereum/utils"
-
 	errorsmod "cosmossdk.io/errors"
-	errortypes "github.com/cosmos/cosmos-sdk/types/errors"
-
-	artela "github.com/artela-network/artela/ethereum/types"
-	evmmodule "github.com/artela-network/artela/x/evm/types"
-
 	sdkmath "cosmossdk.io/math"
+	errortypes "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/ethereum/go-ethereum/common"
 	ethereum "github.com/ethereum/go-ethereum/core/types"
+
+	artela "github.com/artela-network/artela/ethereum/types"
+	"github.com/artela-network/artela/ethereum/utils"
+	evmmodule "github.com/artela-network/artela/x/evm/types"
+	"github.com/artela-network/aspect-core/djpm"
 )
 
 func newAccessListTx(tx *ethereum.Transaction) (*AccessListTx, error) {

--- a/x/evm/txs/tx_dynamic_fee.go
+++ b/x/evm/txs/tx_dynamic_fee.go
@@ -3,20 +3,16 @@ package txs
 import (
 	"math/big"
 
-	"github.com/artela-network/aspect-core/djpm"
-
-	"github.com/artela-network/artela/ethereum/utils"
-
-	sdkmath "cosmossdk.io/math"
-
-	artela "github.com/artela-network/artela/ethereum/types"
-	"github.com/artela-network/artela/x/evm/types"
-
 	errorsmod "cosmossdk.io/errors"
+	sdkmath "cosmossdk.io/math"
 	errortypes "github.com/cosmos/cosmos-sdk/types/errors"
-
 	"github.com/ethereum/go-ethereum/common"
 	ethereum "github.com/ethereum/go-ethereum/core/types"
+
+	artela "github.com/artela-network/artela/ethereum/types"
+	"github.com/artela-network/artela/ethereum/utils"
+	"github.com/artela-network/artela/x/evm/types"
+	"github.com/artela-network/aspect-core/djpm"
 )
 
 func newDynamicFeeTx(tx *ethereum.Transaction) (*DynamicFeeTx, error) {

--- a/x/evm/txs/tx_helper.go
+++ b/x/evm/txs/tx_helper.go
@@ -3,18 +3,17 @@ package txs
 import (
 	"errors"
 	"fmt"
-	"github.com/artela-network/aspect-core/djpm"
 	"math/big"
 
-	"github.com/artela-network/artela-evm/vm"
-
 	sdkmath "cosmossdk.io/math"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/core"
 	ethereum "github.com/ethereum/go-ethereum/core/types"
+
+	"github.com/artela-network/artela-evm/vm"
+	"github.com/artela-network/aspect-core/djpm"
 )
 
 var (

--- a/x/evm/txs/tx_legacy.go
+++ b/x/evm/txs/tx_legacy.go
@@ -1,16 +1,16 @@
 package txs
 
 import (
-	"github.com/artela-network/artela/ethereum/utils"
-	"github.com/artela-network/aspect-core/djpm"
 	"math/big"
-
-	artela "github.com/artela-network/artela/ethereum/types"
-	"github.com/artela-network/artela/x/evm/types"
 
 	errorsmod "cosmossdk.io/errors"
 	"github.com/ethereum/go-ethereum/common"
 	ethereum "github.com/ethereum/go-ethereum/core/types"
+
+	artela "github.com/artela-network/artela/ethereum/types"
+	"github.com/artela-network/artela/ethereum/utils"
+	"github.com/artela-network/artela/x/evm/types"
+	"github.com/artela-network/aspect-core/djpm"
 )
 
 func newLegacyTx(tx *ethereum.Transaction) (*LegacyTx, error) {

--- a/x/evm/txs/tx_utils.go
+++ b/x/evm/txs/tx_utils.go
@@ -4,21 +4,19 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/artela-network/artela/x/evm/txs/support"
+	errorsmod "cosmossdk.io/errors"
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	cosmos "github.com/cosmos/cosmos-sdk/types"
 	errortypes "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/types/msgservice"
 	"github.com/cosmos/cosmos-sdk/types/tx"
-
 	"github.com/cosmos/gogoproto/proto"
-
-	errorsmod "cosmossdk.io/errors"
-	cosmos "github.com/cosmos/cosmos-sdk/types"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/crypto"
+
+	"github.com/artela-network/artela/x/evm/txs/support"
 )
 
 const (

--- a/x/evm/txs/tx_wrapper.go
+++ b/x/evm/txs/tx_wrapper.go
@@ -5,12 +5,6 @@ import (
 	"fmt"
 	"math/big"
 
-	artela "github.com/artela-network/artela/ethereum/types"
-	"github.com/artela-network/artela/ethereum/utils"
-
-	// rpctypes "github.com/artela-network/artela/ethereum/rpc/types"
-	"github.com/artela-network/artela/x/evm/types"
-
 	errorsmod "cosmossdk.io/errors"
 	sdkmath "cosmossdk.io/math"
 	"github.com/cosmos/cosmos-sdk/client"
@@ -25,6 +19,10 @@ import (
 	cmath "github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/core"
 	ethereum "github.com/ethereum/go-ethereum/core/types"
+
+	artela "github.com/artela-network/artela/ethereum/types"
+	"github.com/artela-network/artela/ethereum/utils"
+	"github.com/artela-network/artela/x/evm/types"
 )
 
 var (

--- a/x/evm/types/interfaces.go
+++ b/x/evm/types/interfaces.go
@@ -4,7 +4,6 @@ import (
 	"math/big"
 
 	cosmos "github.com/cosmos/cosmos-sdk/types"
-
 	authmodule "github.com/cosmos/cosmos-sdk/x/auth/types"
 	paramsmodule "github.com/cosmos/cosmos-sdk/x/params/types"
 	stakingmodule "github.com/cosmos/cosmos-sdk/x/staking/types"

--- a/x/fee/blocker.go
+++ b/x/fee/blocker.go
@@ -3,14 +3,13 @@ package fee
 import (
 	"fmt"
 
-	"github.com/artela-network/artela/x/fee/keeper"
-
-	"github.com/artela-network/artela/x/fee/types"
-	abci "github.com/cometbft/cometbft/abci/types"
-
 	sdkmath "cosmossdk.io/math"
+	abci "github.com/cometbft/cometbft/abci/types"
 	"github.com/cosmos/cosmos-sdk/telemetry"
 	cosmos "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/artela-network/artela/x/fee/keeper"
+	"github.com/artela-network/artela/x/fee/types"
 )
 
 // BeginBlock updates base fee

--- a/x/fee/genesis.go
+++ b/x/fee/genesis.go
@@ -2,10 +2,10 @@ package fee
 
 import (
 	errorsmod "cosmossdk.io/errors"
-	"github.com/artela-network/artela/x/fee/keeper"
 	abci "github.com/cometbft/cometbft/abci/types"
 	cosmos "github.com/cosmos/cosmos-sdk/types"
 
+	"github.com/artela-network/artela/x/fee/keeper"
 	"github.com/artela-network/artela/x/fee/types"
 )
 

--- a/x/fee/keeper/base_fee.go
+++ b/x/fee/keeper/base_fee.go
@@ -4,10 +4,11 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/artela-network/artela/x/fee/types"
 	cosmos "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
+
+	"github.com/artela-network/artela/x/fee/types"
 )
 
 // CalculateBaseFee calculates the base fee for the current block. This is only calculated once per

--- a/x/fee/keeper/msg_server.go
+++ b/x/fee/keeper/msg_server.go
@@ -4,9 +4,10 @@ import (
 	"context"
 
 	errorsmod "cosmossdk.io/errors"
-	"github.com/artela-network/artela/x/fee/types"
 	cosmos "github.com/cosmos/cosmos-sdk/types"
 	govmodule "github.com/cosmos/cosmos-sdk/x/gov/types"
+
+	"github.com/artela-network/artela/x/fee/types"
 )
 
 // UpdateParams implements the gRPC MsgServer interface. When an UpdateParams

--- a/x/fee/module.go
+++ b/x/fee/module.go
@@ -9,7 +9,6 @@ import (
 	"github.com/spf13/cobra"
 
 	abci "github.com/cometbft/cometbft/abci/types"
-
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"


### PR DESCRIPTION
Categorize all imports for easier lookup:
1. All imports are divided into 4 groups: standard libraries,  cosmos/cometbft/ethereum libraries,  artela libraries, and other libraries.
2. Within each group, sort them in alphabetical order.