### PR TITLE
Standardize Numbering Format in Documentation for "Build the Source" …

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,17 +34,17 @@ As the first layer 1 network equipped with Aspects, Artela network aims to **max
 ## Build the source
 Artela is a blockchain built using Cosmos SDK and Cometbft and created with [Ignite CLI](https://ignite.com/cli).
 
-1). Set Up Your Go Development Environment<br />
+1. Set Up Your Go Development Environment<br />
 Make sure you have set up your Go programming language development environment.
 
-2). Download the Source Code<br />
+2. Download the Source Code<br />
 Obtain the project source code using the following method:
 
 ```
 git clone https://github.com/artela-network/artela.git
 ```
 
-3). Compile<br />
+3. Compile<br />
 Compile the source code and generate the executable using the Go compiler:
 
 ```


### PR DESCRIPTION
…Section.md

The "Build the Source" section in the documentation currently uses "1)", "2)", ... for numbering steps. To improve consistency and follow standard practices in technical documentation, the numbering format should be updated to **"1.", "2.", ...".

Steps to Reproduce:

1. Open the documentation page containing the "Build the Source" section.


2. Locate the steps under the subsections:

"Set Up Your Go Development Environment"

"Download the Source Code"

"Compile"



3. Observe the numbering format, which currently uses "1)", "2)", "3)", etc.



Proposed Solution:

Change the numbering format from "1)", "2)", ... to "1.", "2.", "3.", ... for all steps.

Example:

Current:

1). Set Up Your Go Development Environment  
2). Download the Source Code

Proposed:

1. Set Up Your Go Development Environment  
2. Download the Source Code



Benefits of the Update:

Follows conventional technical documentation practices.

Improves readability and professionalism.

Maintains consistency with other documentation styles.